### PR TITLE
Sub: HTTP 헤더 팩토리를 비동기로 수행되도록 기존 코드 수정

### DIFF
--- a/packages/http-api/BasicHttpApi.ts
+++ b/packages/http-api/BasicHttpApi.ts
@@ -7,74 +7,74 @@ export class BasicHttpApi implements HttpApi {
   constructor(
     private provider: AsyncHttpNetworkProvider,
     private baseUrl: string,
-    private headersCreator: () => Record<string, string>,
+    private headersCreator: () => Promise<Record<string, string>>,
     private paramsSerializer: (params: any) => string,
     private withCredentials = true
   ) {}
-  get<T = MarshallingType, P = void | Record<string, any>>(
+  async get<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     params?: P,
     timeout?: number
   ): Promise<T> {
     return this.provider.get({
       url: `${this.baseUrl}${url}`,
-      headers: this.headersCreator(),
+      headers: await this.headersCreator(),
       withCredentials: this.withCredentials,
       paramsSerializer: this.paramsSerializer,
       params,
       timeout,
     });
   }
-  post<T = MarshallingType, P = void | Record<string, any>>(
+  async post<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     body?: P,
     timeout?: number
   ): Promise<T> {
     return this.provider.post({
       url: `${this.baseUrl}${url}`,
-      headers: this.headersCreator(),
+      headers: await this.headersCreator(),
       withCredentials: this.withCredentials,
       paramsSerializer: this.paramsSerializer,
       params: body,
       timeout,
     });
   }
-  put<T = MarshallingType, P = void | Record<string, any>>(
+  async put<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     body?: P,
     timeout?: number
   ): Promise<T> {
     return this.provider.put({
       url: `${this.baseUrl}${url}`,
-      headers: this.headersCreator(),
+      headers: await this.headersCreator(),
       withCredentials: this.withCredentials,
       paramsSerializer: this.paramsSerializer,
       params: body,
       timeout,
     });
   }
-  patch<T = MarshallingType, P = void | Record<string, any>>(
+  async patch<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     body?: P,
     timeout?: number
   ): Promise<T> {
     return this.provider.patch({
       url: `${this.baseUrl}${url}`,
-      headers: this.headersCreator(),
+      headers: await this.headersCreator(),
       withCredentials: this.withCredentials,
       paramsSerializer: this.paramsSerializer,
       params: body,
       timeout,
     });
   }
-  delete<T = MarshallingType, P = void | Record<string, any>>(
+  async delete<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     params?: P,
     timeout?: number
   ): Promise<T> {
     return this.provider.delete({
       url: `${this.baseUrl}${url}`,
-      headers: this.headersCreator(),
+      headers: await this.headersCreator(),
       withCredentials: this.withCredentials,
       paramsSerializer: this.paramsSerializer,
       params,
@@ -90,13 +90,13 @@ export class BasicHttpApi implements HttpApi {
       return new File([blob], filename || getFileName(url));
     });
   }
-  getBlob<P = void | Record<string, any>>(
+  async getBlob<P = void | Record<string, any>>(
     url: string,
     params?: P
   ): Promise<Blob> {
     return this.provider.getBlob({
       url: `${this.baseUrl}${url}`,
-      headers: this.headersCreator(),
+      headers: await this.headersCreator(),
       withCredentials: this.withCredentials,
       paramsSerializer: this.paramsSerializer,
       params,

--- a/packages/http-api/network.util.ts
+++ b/packages/http-api/network.util.ts
@@ -1,6 +1,5 @@
-import { AxiosError } from 'axios';
 import { HttpRestError } from '../types';
-import { isObject, isString, isUndefined, isNumber } from '../util/typeCheck';
+import { isNumber, isObject, isString, isUndefined } from '../util/typeCheck';
 import { BaseAsyncHttpNetworkConfig } from './network.type';
 
 function isOptionalBoolean(value: unknown): value is undefined | boolean {
@@ -63,13 +62,25 @@ export function throwHttpRestError(error: unknown) {
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isAxiosError(error: any): error is AxiosError {
-  return (
-    error &&
-    error.response &&
-    typeof error.response.status === 'number' &&
-    error.config &&
-    typeof error.config.url === 'string'
-  );
+export function convertToFormData(
+  data: Record<string, string | File | File[]>
+) {
+  return Object.entries(data).reduce((formData, [key, value]) => {
+    if (Array.isArray(value)) {
+      return value.reduce((innerFormData, file) => {
+        innerFormData.append(key, file, file.name);
+
+        return innerFormData;
+      }, formData);
+    }
+    if (typeof value === 'string') {
+      formData.set(key, value);
+
+      return formData;
+    }
+
+    formData.set(key, value, value.name);
+
+    return formData;
+  }, new FormData());
 }


### PR DESCRIPTION
## Updates

- 추 후 헤더 생성기(header factory)가 비동기로 수행되는 관계로, 이를 이용하는 관련 코드도 모두 비동기로 값을 받아들이도록 변경하였습니다.

## Notes

AsyncQueue 와 JWTProvider 기능 개발에 맞추어 먼저 개선한 코드입니다.
부족한 부분은 다음 작업 때 채울 예정입니다! 😄 