### PR TITLE
Sub: BaseInterceptor 기능 추가, axios delete 수행 시 request body 기능 추가

### DIFF
--- a/packages/http-api/BaseInterceptorHttpApi.ts
+++ b/packages/http-api/BaseInterceptorHttpApi.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { HttpRestErrorLike } from '../types';
+import { HttpInterceptorConfig, RestHttpMethodType } from './network.type';
+
+export class BaseInterceptorHttpApi {
+  private _interceptor: HttpInterceptorConfig = {};
+  public get interceptor(): HttpInterceptorConfig {
+    return this._interceptor;
+  }
+  public set interceptor(value: HttpInterceptorConfig) {
+    this._interceptor = value;
+  }
+
+  constructor(public paramsSerializer: (params: any) => string) {}
+
+  mergeParams = <P>(
+    method: RestHttpMethodType,
+    url: string,
+    paramsOriginal?: P
+  ) => {
+    if (this._interceptor.params) {
+      const paramsAdditional = this._interceptor.params(
+        method,
+        url,
+        paramsOriginal
+      );
+
+      if (paramsAdditional) {
+        if (paramsOriginal) {
+          return {
+            ...paramsOriginal,
+            ...paramsAdditional,
+          };
+        }
+        return paramsAdditional;
+      }
+    }
+
+    return paramsOriginal;
+  };
+
+  mergeQueries = <P>(
+    method: RestHttpMethodType,
+    url: string,
+    paramsOriginal?: P
+  ) => {
+    if (this._interceptor.params) {
+      const paramsAdditional = this._interceptor.params(
+        method,
+        url,
+        paramsOriginal
+      );
+
+      if (!paramsAdditional) {
+        return url;
+      }
+
+      return (
+        url +
+        (url.includes('?') ? '&' : '?') +
+        this.paramsSerializer(paramsAdditional)
+      );
+    }
+
+    return url;
+  };
+
+  throwWithInterceptor = <E extends HttpRestErrorLike = any>(
+    err: E
+  ): Promise<any> => {
+    if (this._interceptor.error) {
+      const nextError = this._interceptor.error(err);
+
+      if (nextError) {
+        throw nextError;
+      }
+    }
+
+    throw err;
+  };
+}

--- a/packages/http-api/axios/AxiosHttpNetworkProvider.ts
+++ b/packages/http-api/axios/AxiosHttpNetworkProvider.ts
@@ -68,10 +68,16 @@ export class AxiosHttpNetworkProvider implements AsyncHttpNetworkProvider {
       .then(this.extractData);
   }
 
-  delete<T>({ url, headers, ...config }: AsyncHttpNetworkConfig): Promise<T> {
+  delete<T>({
+    url,
+    headers,
+    params: data,
+    ...config
+  }: AsyncHttpNetworkConfig): Promise<T> {
     return axios
       .delete<T>(url, {
         ...config,
+        data,
         headers: this.makeAxiosHeaders(headers),
       })
       .then(this.extractData);


### PR DESCRIPTION
## Updates

- HttpApi 및 HttpUploadApi 에서 상속받아서 쓸 인터셉터 처리기를 작성합니다.
- BE API 의 delete 메서드 사용 시 body request 를 원하는 정책이 생겨 이를 따르도록 axios 의 delete 메서드 수행 코드를 개선하였습니다.

## Notes

- 가급적 상속(extends)을 안쓰려 했으나, 똑같은 메서드와 프로퍼티를 2번(!!) 복붙해서 각 클래스에 넣는건 좀 아니라는 생각이 들었습니다 🤔 
- 그래서 오랜만에(?) 확장을 목적으로 한 base class 를 만들었습니다.