### PR TITLE
Hotfix: 네트워크 계층에서 헤더 오류 발생 시 error interceptor 를 안거치는 문제 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jordy",
-  "version": "0.13.0",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jordy",
-      "version": "0.13.0",
+      "version": "0.14.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "typescript based frontend toolkit",
   "main": "./esm5/index.js",
   "module": "./esm5/index.js",

--- a/packages/http-api/BasicHttpApi.test.ts
+++ b/packages/http-api/BasicHttpApi.test.ts
@@ -179,18 +179,23 @@ describe('BasicHttpApi', () => {
         );
       });
 
-      it('오류가 발생되지 않는다면 error interceptor 를 호출하지 않는다.', async () => {
-        await httpApi[method]('/user/search', { q: 'lookpin' });
-
-        expect(errorInterMock).not.toBeCalled();
-      });
-
-      it('header 에서 오류 발생 시 error interceptor 를 호출하지 않는다.', async () => {
-        headerCreatorMock.mockRejectedValueOnce(new Error('some error!'));
+      it('header 에서 오류 발생 시 error interceptor 를 호출한다.', async () => {
+        headerCreatorMock.mockRejectedValueOnce(new Error('need to login!'));
 
         await expect(
           httpApi[method]('/user/search', { q: 'lookpin' })
         ).rejects.toThrow();
+
+        expect(errorInterMock).toBeCalledTimes(1);
+        expect(errorInterMock).toBeCalledWith(
+          expect.objectContaining({
+            message: 'need to login!',
+          })
+        );
+      });
+
+      it('오류가 발생되지 않는다면 error interceptor 를 호출하지 않는다.', async () => {
+        await httpApi[method]('/user/search', { q: 'lookpin' });
 
         expect(errorInterMock).not.toBeCalled();
       });
@@ -323,18 +328,23 @@ describe('BasicHttpApi', () => {
         );
       });
 
-      it('오류가 발생되지 않는다면 error interceptor 를 호출하지 않는다.', async () => {
-        await httpApi.getBlob('/user/search', { q: 'lookpin' });
-
-        expect(errorInterMock).not.toBeCalled();
-      });
-
-      it('header 에서 오류 발생 시 error interceptor 를 호출하지 않는다.', async () => {
-        headerCreatorMock.mockRejectedValueOnce(new Error('some error!'));
+      it('header 에서 오류 발생 시 error interceptor 를 호출한다.', async () => {
+        headerCreatorMock.mockRejectedValueOnce(new Error('need to login!'));
 
         await expect(
           httpApi.getBlob('/user/search', { q: 'lookpin' })
         ).rejects.toThrow();
+
+        expect(errorInterMock).toBeCalledTimes(1);
+        expect(errorInterMock).toBeCalledWith(
+          expect.objectContaining({
+            message: 'need to login!',
+          })
+        );
+      });
+
+      it('오류가 발생되지 않는다면 error interceptor 를 호출하지 않는다.', async () => {
+        await httpApi.getBlob('/user/search', { q: 'lookpin' });
 
         expect(errorInterMock).not.toBeCalled();
       });

--- a/packages/http-api/BasicHttpApi.ts
+++ b/packages/http-api/BasicHttpApi.ts
@@ -23,90 +23,100 @@ export class BasicHttpApi
     params?: P,
     timeout?: number
   ): Promise<T> {
-    const headers = await this.headersCreator();
+    try {
+      const headers = await this.headersCreator();
 
-    return this.provider
-      .get({
+      return await this.provider.get({
         url: `${this.baseUrl}${url}`,
         headers,
         withCredentials: this.withCredentials,
         paramsSerializer: this.paramsSerializer,
         params: this.mergeParams('get', url, params),
         timeout,
-      })
-      .catch(this.throwWithInterceptor) as Promise<T>;
+      });
+    } catch (error) {
+      this.throwWithInterceptor(error);
+    }
   }
   async post<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     body?: P,
     timeout?: number
   ): Promise<T> {
-    const headers = await this.headersCreator();
+    try {
+      const headers = await this.headersCreator();
 
-    return this.provider
-      .post({
+      return await this.provider.post({
         url: `${this.baseUrl}${this.mergeQueries('post', url, body)}`,
         headers,
         withCredentials: this.withCredentials,
         paramsSerializer: this.paramsSerializer,
         params: body,
         timeout,
-      })
-      .catch(this.throwWithInterceptor) as Promise<T>;
+      });
+    } catch (error) {
+      this.throwWithInterceptor(error);
+    }
   }
   async put<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     body?: P,
     timeout?: number
   ): Promise<T> {
-    const headers = await this.headersCreator();
+    try {
+      const headers = await this.headersCreator();
 
-    return this.provider
-      .put({
+      return await this.provider.put({
         url: `${this.baseUrl}${this.mergeQueries('put', url, body)}`,
         headers,
         withCredentials: this.withCredentials,
         paramsSerializer: this.paramsSerializer,
         params: body,
         timeout,
-      })
-      .catch(this.throwWithInterceptor) as Promise<T>;
+      });
+    } catch (error) {
+      this.throwWithInterceptor(error);
+    }
   }
   async patch<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     body?: P,
     timeout?: number
   ): Promise<T> {
-    const headers = await this.headersCreator();
+    try {
+      const headers = await this.headersCreator();
 
-    return this.provider
-      .patch({
+      return await this.provider.patch({
         url: `${this.baseUrl}${this.mergeQueries('patch', url, body)}`,
         headers,
         withCredentials: this.withCredentials,
         paramsSerializer: this.paramsSerializer,
         params: body,
         timeout,
-      })
-      .catch(this.throwWithInterceptor) as Promise<T>;
+      });
+    } catch (error) {
+      this.throwWithInterceptor(error);
+    }
   }
   async delete<T = MarshallingType, P = void | Record<string, any>>(
     url: string,
     body?: P,
     timeout?: number
   ): Promise<T> {
-    const headers = await this.headersCreator();
+    try {
+      const headers = await this.headersCreator();
 
-    return this.provider
-      .delete({
+      return await this.provider.delete({
         url: `${this.baseUrl}${this.mergeQueries('delete', url, body)}`,
         headers,
         withCredentials: this.withCredentials,
         paramsSerializer: this.paramsSerializer,
         params: body,
         timeout,
-      })
-      .catch(this.throwWithInterceptor) as Promise<T>;
+      });
+    } catch (error) {
+      this.throwWithInterceptor(error);
+    }
   }
 
   getFile<P = void | Record<string, any>>(
@@ -124,16 +134,18 @@ export class BasicHttpApi
     url: string,
     params?: P
   ): Promise<Blob> {
-    const headers = await this.headersCreator();
+    try {
+      const headers = await this.headersCreator();
 
-    return this.provider
-      .getBlob({
+      return await this.provider.getBlob({
         url: `${this.baseUrl}${url}`,
         headers,
         withCredentials: this.withCredentials,
         paramsSerializer: this.paramsSerializer,
         params: this.mergeParams('get', url, params),
-      })
-      .catch(this.throwWithInterceptor);
+      });
+    } catch (error) {
+      this.throwWithInterceptor(error);
+    }
   }
 }

--- a/packages/http-api/BasicHttpUploadApi.test.ts
+++ b/packages/http-api/BasicHttpUploadApi.test.ts
@@ -194,18 +194,23 @@ describe('BasicHttpUploadApi', () => {
         );
       });
 
-      it('오류가 발생되지 않는다면 error interceptor 를 호출하지 않는다.', async () => {
-        await httpApi[`${method}Upload`]('/user/search', { q: 'lookpin' });
-
-        expect(errorInterMock).not.toBeCalled();
-      });
-
-      it('header 에서 오류 발생 시 error interceptor 를 호출하지 않는다.', async () => {
-        headerCreatorMock.mockRejectedValueOnce(new Error('some error!'));
+      it('header 에서 오류 발생 시 error interceptor 를 호출한다.', async () => {
+        headerCreatorMock.mockRejectedValueOnce(new Error('need to login!'));
 
         await expect(
           httpApi[`${method}Upload`]('/user/search', { q: 'lookpin' })
         ).rejects.toThrow();
+
+        expect(errorInterMock).toBeCalledTimes(1);
+        expect(errorInterMock).toBeCalledWith(
+          expect.objectContaining({
+            message: 'need to login!',
+          })
+        );
+      });
+
+      it('오류가 발생되지 않는다면 error interceptor 를 호출하지 않는다.', async () => {
+        await httpApi[`${method}Upload`]('/user/search', { q: 'lookpin' });
 
         expect(errorInterMock).not.toBeCalled();
       });

--- a/packages/http-api/BasicHttpUploadApi.ts
+++ b/packages/http-api/BasicHttpUploadApi.ts
@@ -29,18 +29,20 @@ export class BasicHttpUploadApi
     progressCallback?: (args: UploadStateArgs) => void,
     timeout?: number
   ): Promise<T> {
-    const headers = await this.headersCreator();
+    try {
+      const headers = await this.headersCreator();
 
-    return this.provider
-      .post({
+      return await this.provider.post({
         url: `${this.baseUrl}${this.mergeQueries('post', url, data)}`,
         headers,
         withCredentials: this.withCredentials,
         data,
         timeout,
         onProgress: progressCallback,
-      })
-      .catch(this.throwWithInterceptor) as Promise<T>;
+      });
+    } catch (error) {
+      this.throwWithInterceptor(error);
+    }
   }
 
   async putUpload<
@@ -52,17 +54,19 @@ export class BasicHttpUploadApi
     progressCallback?: (args: UploadStateArgs) => void,
     timeout?: number
   ): Promise<T> {
-    const headers = await this.headersCreator();
+    try {
+      const headers = await this.headersCreator();
 
-    return this.provider
-      .put({
+      return await this.provider.put({
         url: `${this.baseUrl}${this.mergeQueries('put', url, data)}`,
         headers,
         withCredentials: this.withCredentials,
         data,
         timeout,
         onProgress: progressCallback,
-      })
-      .catch(this.throwWithInterceptor) as Promise<T>;
+      });
+    } catch (error) {
+      this.throwWithInterceptor(error);
+    }
   }
 }


### PR DESCRIPTION
## Fixes

- HttpApi 및 HttpUploadApi 운용 중 header creator 에서 오류 발생 시 설정된 error interceptor 를 거치지 않는 문제를 수정합니다.

## Notes

- 이제보니 테스트 코드에서 빠진게 아니라 애초에 의도된(?) 것이었습니다 😭 
- 근데 원래 의도 했던 것은 이게 아니었기에 다시 header 에서 오류 발생 시 동일한 error interceptor 를 거치도록 기능을 수정하였습니다.
- 이 후 또 다른 수정사항이 발생될 수 있음을 양해바랍니다~ 🙏 