### PR TITLE
Hotfix: HttpRestError 생성 오류 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jordy",
-  "version": "0.14.1",
+  "version": "0.14.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jordy",
-      "version": "0.14.1",
+      "version": "0.14.4",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.15.8",
@@ -38,7 +38,7 @@
         "tslib": "^2.3.1",
         "typescript": "^4.7.4",
         "vite": "^3.0.2",
-        "vitest": "^0.18.1"
+        "vitest": "^0.22.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2250,9 +2250,9 @@
       "dev": true
     },
     "node_modules/@types/chai": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
-      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
       "dev": true
     },
     "node_modules/@types/chai-subset": {
@@ -6854,9 +6854,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.0.tgz",
-      "integrity": "sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
+      "integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -7224,19 +7224,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.18.1.tgz",
-      "integrity": "sha512-4F/1K/Vn4AvJwe7i2YblR02PT5vMKcw9KN4unDq2KD0YcSxX0B/6D6Qu9PJaXwVuxXMFTQ5ovd4+CQaW3bwofA==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.22.1.tgz",
+      "integrity": "sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==",
       "dev": true,
       "dependencies": {
-        "@types/chai": "^4.3.1",
+        "@types/chai": "^4.3.3",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
         "chai": "^4.3.6",
         "debug": "^4.3.4",
         "local-pkg": "^0.4.2",
         "tinypool": "^0.2.4",
-        "tinyspy": "^1.0.0",
+        "tinyspy": "^1.0.2",
         "vite": "^2.9.12 || ^3.0.0-0"
       },
       "bin": {
@@ -7250,8 +7250,8 @@
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
         "@vitest/ui": "*",
-        "c8": "*",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -7259,10 +7259,10 @@
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@vitest/ui": {
+        "@vitest/browser": {
           "optional": true
         },
-        "c8": {
+        "@vitest/ui": {
           "optional": true
         },
         "happy-dom": {
@@ -9037,9 +9037,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
-      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
       "dev": true
     },
     "@types/chai-subset": {
@@ -12418,9 +12418,9 @@
       "dev": true
     },
     "tinyspy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.0.tgz",
-      "integrity": "sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
+      "integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
       "dev": true
     },
     "to-fast-properties": {
@@ -12656,19 +12656,19 @@
       }
     },
     "vitest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.18.1.tgz",
-      "integrity": "sha512-4F/1K/Vn4AvJwe7i2YblR02PT5vMKcw9KN4unDq2KD0YcSxX0B/6D6Qu9PJaXwVuxXMFTQ5ovd4+CQaW3bwofA==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.22.1.tgz",
+      "integrity": "sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==",
       "dev": true,
       "requires": {
-        "@types/chai": "^4.3.1",
+        "@types/chai": "^4.3.3",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
         "chai": "^4.3.6",
         "debug": "^4.3.4",
         "local-pkg": "^0.4.2",
         "tinypool": "^0.2.4",
-        "tinyspy": "^1.0.0",
+        "tinyspy": "^1.0.2",
         "vite": "^2.9.12 || ^3.0.0-0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.14.2",
+  "version": "0.14.4",
   "description": "typescript based frontend toolkit",
   "main": "./esm5/index.js",
   "module": "./esm5/index.js",
@@ -52,7 +52,7 @@
     "tslib": "^2.3.1",
     "typescript": "^4.7.4",
     "vite": "^3.0.2",
-    "vitest": "^0.18.1"
+    "vitest": "^0.22.1"
   },
   "files": [
     "esm5/**/*.js",

--- a/packages/types/HttpRestError.test.ts
+++ b/packages/types/HttpRestError.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  HttpRestError,
+  HttpRestErrorLike,
+  HttpRestErrorMetaArgs,
+} from './HttpRestError';
+
+describe('HttpRestError', () => {
+  it('첫번째 인자는 메시지로 적용된다.', () => {
+    const result = new HttpRestError('blah');
+
+    expect(result.message).toBe('blah');
+  });
+  describe('두번째 인자에 지정된 문자열을 넣으면 에러 타입으로 적용된다.', () => {
+    it.each([
+      'unknown',
+      'auth',
+      'forbidden',
+      'notFound',
+      'badRequest',
+      'server',
+    ] as const)('%s 값', (errorType) => {
+      const result = new HttpRestError('lookpin!', errorType);
+
+      expect(result.errorType).toBe(errorType);
+    });
+  });
+  describe('두번째 인자에 숫자를 넣으면 HTTP Status Code 로 인식 시도한다.', () => {
+    it.each([
+      [
+        0,
+        'unknown',
+        100,
+        'unknown',
+        200,
+        'unknown',
+        300,
+        'unknown',
+        400,
+        'badRequest',
+        401,
+        'auth',
+        403,
+        'forbidden',
+        404,
+        'notFound',
+        410,
+        'badRequest',
+        499,
+        'badRequest',
+        500,
+        'server',
+        510,
+        'server',
+        599,
+        'server',
+        600,
+        'unknown',
+        700,
+        'unknown',
+      ],
+    ])('%s 값 -> %s', (code, type) => {
+      const result = new HttpRestError('lookpin', code);
+
+      expect(result.errorType).toBe(type);
+    });
+  });
+  describe('두번째 인자에 인식할 수 없는 값이 들어가면 unknown 으로 적용된다.', () => {
+    it.each([null, '', undefined, NaN, true, false, {}, () => true])(
+      '"%s" 값',
+      (value) => {
+        const result = new HttpRestError('lookpin', value as any);
+
+        expect(result.errorType).toBe('unknown');
+      }
+    );
+  });
+  it('두번째 인자가 HttpRestError 와 유사하다면 그 값을 그대로 적용한다.', () => {
+    const given: HttpRestErrorLike = {
+      message: 'theson',
+      url: 'blah blah path',
+      errorType: 'badRequest',
+      rawData: {
+        message: 'oh~ lookpin!!',
+      },
+    };
+    const result = new HttpRestError('theson', given);
+
+    expect(result).toContain({
+      ...given,
+    });
+  });
+  describe('두번째 인자가 비어있진 않은데 문자열이 아니라면 메타 정보라 판단하고 적용 시도한다.', () => {
+    it.each([
+      [
+        '의도했던 자료',
+        {
+          url: 'lookpin/home/page',
+          status: 404,
+          rawData: {
+            status: '뭔지 모르지만 일단 오류',
+            message: '흥해라 룩핀!',
+          },
+        },
+        'notFound',
+      ],
+      [
+        '필드는 있으나 의도하지 않던 값',
+        {
+          url: null,
+          status: 123,
+          rawData: null,
+        },
+        'unknown',
+      ],
+      [
+        '필드가 부족함',
+        {
+          url: '',
+          blahBlah: NaN,
+        },
+        'unknown',
+      ],
+      ['모든 필드가 비었음', {}, 'unknown'],
+    ])('%s', (_, arg: HttpRestErrorMetaArgs, errorType) => {
+      const result = new HttpRestError('lookpin', arg);
+
+      expect(result).toContain({
+        url: arg.url || '',
+        errorType,
+        rawData: arg.rawData,
+      });
+    });
+  });
+});

--- a/packages/types/HttpRestError.ts
+++ b/packages/types/HttpRestError.ts
@@ -61,7 +61,7 @@ export class HttpRestError extends Error implements HttpRestErrorLike {
     super(message);
 
     if (typeof arg1 === 'number') {
-      this._errorType = this.toErrorType(arg1);
+      this._errorType = HttpRestError.toErrorType(arg1);
 
       return;
     }
@@ -79,12 +79,21 @@ export class HttpRestError extends Error implements HttpRestErrorLike {
     }
     if (typeof arg1 !== 'string' && arg1) {
       this._url = arg1.url || '';
-      this._errorType = this.toErrorType(arg1.status);
+      this._errorType = HttpRestError.toErrorType(arg1.status);
       this._rawData = arg1.rawData;
     }
   }
 
-  toErrorType(status: number): HttpRestErrorType {
+  toPlainObject(): HttpRestErrorLike {
+    return {
+      message: this.message,
+      errorType: this._errorType,
+      url: this._url,
+      rawData: this._rawData,
+    };
+  }
+
+  static toErrorType(status: number): HttpRestErrorType {
     if (status === 401) {
       return 'auth';
     }
@@ -97,19 +106,10 @@ export class HttpRestError extends Error implements HttpRestErrorLike {
     if (status >= 500) {
       return 'server';
     }
-    if (status < 500) {
+    if (status >= 400 && status < 500) {
       return 'badRequest';
     }
     return 'unknown';
-  }
-
-  toPlainObject(): HttpRestErrorLike {
-    return {
-      message: this.message,
-      errorType: this._errorType,
-      url: this._url,
-      rawData: this._rawData,
-    };
   }
 
   static isHttpRestErrorType(value: unknown): value is HttpRestErrorType {


### PR DESCRIPTION
## Fixes

- ErrorParser 를 거쳐서 균일하게 만들어진 HttpRestError 가 생성 시 오류가 발생되는 점이 발견되어 수정합니다.
- 추가로 HttpRestError 와 관련된 테스트 코드를 작성합니다.

## Others

- vitest 버전업 : 0.18.1 -> 0.22.1

## Notes

음.. 이게 이전 코드 기준으로 테스트 과정에서는 같은 오류가 발생되지 않았습니다.
근데 실제 사용할 때 오류가 발생 되고 있습니다~ 🤔 
주요 원인은 `toErrorType` 메서드가 비어서.. 라는데,
일단 이 부분은 static method 로 바꾸어 동일하게 테스트 통과되도록 기능 변경 했습니다.

<img width="421" alt="image" src="https://user-images.githubusercontent.com/16861056/187621859-ccec1a92-4e9b-4b76-a078-97764be207a8.png">

또 오류가 발생되면, 배포 먼저하고 테스트 진행해서 해결되면 그 때 별도 PR 올리겠습니다~ 🙏 
