### PR TITLE
Test: RefreshableJWTProvider 테스트 코드 보완 외

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 업무용 프론트엔드 프로젝트에서 아키텍쳐 도입시 쓰이는 툴킷 모음 입니다.
 
 ## Requires
-- react-router
-- react-router-dom
+- react-router-dom@6.3.x
 - axios
 - redux
 - react-redux

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jordy",
-  "version": "0.14.11",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jordy",
-      "version": "0.14.11",
+      "version": "0.15.0",
       "license": "ISC",
       "devDependencies": {
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.14.17",
+  "version": "0.15.0",
   "description": "typescript based frontend toolkit",
   "repository": {
     "type": "git",

--- a/packages/http-api/BasicHttpApi.ts
+++ b/packages/http-api/BasicHttpApi.ts
@@ -13,7 +13,7 @@ export class BasicHttpApi
     private baseUrl: string,
     private headersCreator: () => Promise<Record<string, string>>,
     paramsSerializer: (params: any) => string,
-    private withCredentials = true
+    private withCredentials = false
   ) {
     super(paramsSerializer);
   }

--- a/packages/http-api/BasicHttpUploadApi.ts
+++ b/packages/http-api/BasicHttpUploadApi.ts
@@ -15,7 +15,7 @@ export class BasicHttpUploadApi
     private baseUrl: string,
     private headersCreator: () => Promise<Record<string, string>>,
     paramsSerializer: (params: any) => string,
-    private withCredentials = true
+    private withCredentials = false
   ) {
     super(paramsSerializer);
   }

--- a/packages/http-api/createHttpHeaderPipe.ts
+++ b/packages/http-api/createHttpHeaderPipe.ts
@@ -3,13 +3,9 @@ import { JWTProvider } from '../jwt';
 import { TokenProvider } from '../storage';
 import { isServer } from '../util/envCheck';
 import { HttpRestError } from './HttpRestError';
+import { HeaderFieldMakingOperator } from './network.type';
 
-type HeaderFieldMaker = (
-  defHeader: Map<string, string>,
-  token?: string
-) => Map<string, string>;
-
-function makeHeaders(pipes: HeaderFieldMaker[], token = '') {
+function makeHeaders(pipes: HeaderFieldMakingOperator[], token = '') {
   const rawMap = pipes.reduce(
     (prev, fn) => fn(prev, token),
     new Map<string, string>()
@@ -67,7 +63,7 @@ export const createHttpHeaderPipe = (
   provider?: TokenProvider | JWTProvider,
   loginRequiredMessage = MSG_DEFAULT
 ) => {
-  return async function headerPipe(...pipes: HeaderFieldMaker[]) {
+  return async function headerPipe(...pipes: HeaderFieldMakingOperator[]) {
     let token = '';
 
     if (provider) {

--- a/packages/http-api/createTokenRefresher.ts
+++ b/packages/http-api/createTokenRefresher.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { JWTAuthTokenDto } from '../jwt';
+import { TokenProvider } from '../storage';
+import { qs } from '../util';
+import { createHttpApi } from './createHttpApi.factory';
+import { createHttpHeaderPipe } from './createHttpHeaderPipe';
+import { HeaderFieldMakingOperator, HttpApi } from './network.type';
+
+interface TokenRefresherConfig {
+  /**
+   * 수행 도메인 경로
+   */
+  baseUrl: string;
+  /**
+   * 리프레시 수행에 필요한 헤더를 만드는 오퍼레이터 함수들.
+   *
+   * bearer token 형태가 쓰인다면 `httpHeaderOperator.bearerToken` 를 사용하면 된다.
+   *
+   * 만약 다른 형태의 헤더라면 직접 구현하여 연결한다.
+   */
+  headerOperators: HeaderFieldMakingOperator[];
+  /**
+   * 실제 리프레시를 호출하여 토큰 자료를 제공하는곳.
+   *
+   * 인자로 들어오는 httpApi 를 이용하여 호출하고 응답값을 JWTAuthTokenDto 에 맞게 바꿔주어야 한다.
+   *
+   * @see HttpApi
+   * @see JWTAuthTokenDto
+   */
+  mapper: (httpApi: HttpApi) => Promise<JWTAuthTokenDto>;
+  /**
+   * 쿼리 파라미터 이용 시 직렬화 할 유틸리티 함수.
+   *
+   * @default qs.serialize
+   */
+  paramsSerializer?: (params: any) => string;
+  /**
+   * CORS 사용시 요청 헤더에 관련 쿠키 정보를 포함시킬지 여부.
+   *
+   * @default false
+   */
+  withCredentials?: boolean;
+}
+
+class PassthroughTokenProvider implements TokenProvider {
+  private token = '';
+
+  get(): string {
+    return this.token;
+  }
+  set(token: string): void {
+    this.token = token;
+  }
+  clear(): void {
+    this.token = '';
+  }
+}
+
+/**
+ * JWT 토큰을 리프레시 할 때 필요한 함수를 생성한다.
+ *
+ * @example
+ * import { createTokenRefresher, httpHeaderOperator } from 'jordy';
+ *
+ * interface AuthTokenRes {
+ *   access: string;
+ *   refresh: string;
+ * }
+ *
+ * const refresher = createTokenRefresher({
+ *   baseUrl: 'https://api.jordy.com',
+ *   headerOperators: [
+ *     httpHeaderOperator.bearerToken,
+ *   ],
+ *   mapper: async (httpApi) => {
+ *     const res = await httpApi.post<AuthTokenRes>('/token/refresh/path');
+ *
+ *     return {
+ *       accessToken: res.access,
+ *       refreshToken: res.refresh,
+ *     };
+ *   }
+ * });
+ *
+ * const jwtProvider = createJWTProvider({
+ *   accessTokenKey: 'myAccess',
+ *   refreshTokenKey: 'myRefresh',
+ *   tokenRefresher: refresher,
+ * });
+ *
+ * @param param0
+ * @returns
+ */
+export function createTokenRefresher({
+  baseUrl,
+  headerOperators,
+  mapper,
+  paramsSerializer = qs.serialize,
+  withCredentials = false,
+}: TokenRefresherConfig) {
+  const provider = new PassthroughTokenProvider();
+  const createHeaderProvider = () => {
+    const pipe = createHttpHeaderPipe(provider);
+
+    return pipe.apply(pipe, headerOperators);
+  };
+
+  const refreshTokenApi = createHttpApi(
+    baseUrl,
+    createHeaderProvider,
+    paramsSerializer,
+    withCredentials
+  );
+
+  return async function tokenRefresher(refreshToken: string) {
+    provider.set(refreshToken);
+
+    const result = await mapper(refreshTokenApi);
+
+    return result;
+  };
+}

--- a/packages/http-api/index.ts
+++ b/packages/http-api/index.ts
@@ -3,6 +3,7 @@ export * from './BasicHttpUploadApi';
 export * from './createHttpApi.factory';
 export * from './createHttpHeaderPipe';
 export * from './createHttpUploadApi.factory';
-export * from './network.type';
+export * from './createTokenRefresher';
 export * from './httpHeaderOperator';
 export * from './HttpRestError';
+export * from './network.type';

--- a/packages/http-api/network.type.ts
+++ b/packages/http-api/network.type.ts
@@ -4,6 +4,11 @@ import { HttpRestErrorLike } from './HttpRestError';
 
 export type RestHttpMethodType = 'get' | 'post' | 'put' | 'patch' | 'delete';
 
+export type HeaderFieldMakingOperator = (
+  defHeader: Map<string, string>,
+  token?: string
+) => Map<string, string>;
+
 /**
  * 업로드 상태를 확인할 수 있는 객체.
  */

--- a/packages/jwt/RefreshableJWTProvider.test.ts
+++ b/packages/jwt/RefreshableJWTProvider.test.ts
@@ -1,8 +1,8 @@
+import { TokenProvider } from '../storage/storage.type';
 import { PromiseResolver } from '../types';
 import { noop } from '../util';
-import { RefreshableJWTProvider } from './RefreshableJWTProvider';
-import { TokenProvider } from '../storage/storage.type';
 import { JWTAuthTokenDto } from './jwt.type';
+import { RefreshableJWTProvider } from './RefreshableJWTProvider';
 
 describe('RefreshableJWTProvider', () => {
   const TOKEN = {
@@ -38,12 +38,12 @@ describe('RefreshableJWTProvider', () => {
   };
   const accessTokenMock = {
     get: vi.fn(() => TOKEN.PROVIDER.ACCESS),
-    set: vi.fn().mockImplementation(noop),
+    set: vi.fn(noop),
     clear: vi.fn(),
   };
   const refreshTokenMock = {
     get: vi.fn(() => TOKEN.PROVIDER.REFRESH),
-    set: vi.fn().mockImplementation(noop),
+    set: vi.fn(noop),
     clear: vi.fn(),
   };
   const refresherMock = vi.fn().mockResolvedValue(AUTH_TOKEN_DTO);
@@ -80,6 +80,8 @@ describe('RefreshableJWTProvider', () => {
       expect(refresherMock).not.toBeCalled();
 
       await provider.get();
+
+      expect(refresherMock).toBeCalled();
 
       refresherMock.mockClear();
 
@@ -133,6 +135,23 @@ describe('RefreshableJWTProvider', () => {
           message: 'error!',
         })
       );
+
+      expect(refresherMock).toBeCalled();
+    });
+
+    it('refresh 실패 시 refreshed 는 false 로 바뀐다.', async () => {
+      await provider.get();
+
+      expect(provider.refreshed).toBe(true);
+
+      accessTokenMock.get.mockReturnValueOnce('');
+      refresherMock.mockRejectedValueOnce(new Error('what the lookpin ?!'));
+
+      await expect(provider.get()).rejects.toThrow();
+
+      expect(accessTokenMock.get).toBeCalled();
+      expect(refresherMock).toBeCalled();
+      expect(provider.refreshed).toBe(false);
     });
 
     it('refresh 성공 후 토큰값 요청을 여러번 하면, 내부 토큰 제공자에 위임하여 이것이 가진 값을 내보낸다.', async () => {
@@ -203,33 +222,45 @@ describe('RefreshableJWTProvider', () => {
   });
 
   describe('토큰 만료시 동작', () => {
+    beforeEach(() => {
+      provider.set(AUTH_TOKEN_DTO);
+    });
+
     it('가져올 엑세스 토큰이 만료 되었다면 refresh 를 자체적으로 수행한다.', async () => {
-      accessTokenMock.get.mockImplementationOnce(() => '');
+      const refreshFnMock = vi.spyOn(provider, 'refresh');
+
+      accessTokenMock.get.mockReturnValueOnce('');
 
       expect(refresherMock).not.toBeCalled();
 
       await provider.get();
 
-      expect(refresherMock).toBeCalled();
+      expect(accessTokenMock.get).toBeCalled();
+      expect(refreshFnMock).toBeCalled();
+
+      refreshFnMock.mockRestore();
     });
 
     it('엑세스 토큰 만료로 refresh 도중 오류가 발생된다면 그 내용을 catch 에 전달한다.', async () => {
-      accessTokenMock.get.mockImplementationOnce(() => '');
+      accessTokenMock.get.mockReturnValueOnce('');
       refresherMock.mockRejectedValueOnce(new Error('lookpin!'));
 
       await expect(provider.get()).rejects.toThrowError('lookpin!');
 
+      expect(accessTokenMock.get).toBeCalled();
       expect(refresherMock).toBeCalled();
     });
 
     it('엑세스 토큰과 리프레시 토큰 2개 모두 만료 되었다면 오류를 일으킨다.', async () => {
-      accessTokenMock.get.mockImplementationOnce(() => '');
-      refreshTokenMock.get.mockImplementationOnce(() => '');
+      accessTokenMock.get.mockReturnValueOnce('');
+      refreshTokenMock.get.mockReturnValueOnce('');
 
       await expect(provider.get()).rejects.toThrowError(
         RefreshableJWTProvider.MSG_LOGIN_REQUIRED
       );
 
+      expect(accessTokenMock.get).toBeCalled();
+      expect(refreshTokenMock.get).toBeCalled();
       expect(refresherMock).not.toBeCalled();
     });
   });
@@ -243,6 +274,39 @@ describe('RefreshableJWTProvider', () => {
       provider.clear();
 
       expect(provider.refreshed).toBe(false);
+    });
+  });
+
+  describe('setter 동작', () => {
+    it('토큰값을 직접 설정 시 refreshed 상태가 true 가 된다.', () => {
+      expect(provider.refreshed).toBe(false);
+
+      provider.set(AUTH_TOKEN_DTO);
+
+      expect(provider.refreshed).toBe(true);
+    });
+    it('직접 설정 후 토큰값을 가져오면 refresh 를 수행하지 않는다.', async () => {
+      provider.set(AUTH_TOKEN_DTO);
+
+      await provider.get();
+
+      expect(refresherMock).not.toBeCalled();
+    });
+    it('직접 설정된 토큰값은 내부 토큰제공자에 설정되고 이 곳에서 가져온다.', async () => {
+      const sampleToken = 'world best shopping mall, lookpin!';
+      accessTokenMock.get.mockReturnValue(sampleToken);
+
+      provider.set({
+        accessToken: sampleToken,
+        refreshToken: 'theson',
+      });
+
+      const result = await provider.get();
+
+      expect(accessTokenMock.set).toBeCalledWith(sampleToken, undefined);
+      expect(accessTokenMock.get).toBeCalledTimes(1);
+
+      expect(result).toBe(sampleToken);
     });
   });
 });

--- a/packages/jwt/RefreshableJWTProvider.ts
+++ b/packages/jwt/RefreshableJWTProvider.ts
@@ -34,7 +34,7 @@ export class RefreshableJWTProvider implements JWTProvider {
 
   async refresh() {
     const defaultErrorMessage = RefreshableJWTProvider.MSG_LOGIN_REQUIRED;
-    const token = this.refreshToken;
+    const token = this.refreshTokenProvider.get();
 
     if (token) {
       try {
@@ -60,6 +60,7 @@ export class RefreshableJWTProvider implements JWTProvider {
       tokenValue.refreshToken,
       tokenValue.refreshTokenExpiredDate
     );
+    this._refreshed = true;
   }
   async get(): Promise<string> {
     if (this._refreshed) {
@@ -80,7 +81,6 @@ export class RefreshableJWTProvider implements JWTProvider {
       this.set(value);
 
       this._pending = false;
-      this._refreshed = true;
 
       if (this.asyncQueue.has()) {
         this.asyncQueue.resolveAll(value.accessToken);


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

### RefreshableJWTProvider

- setter 를 통해 토큰값을 주었을 때 refreshed 상태가 true 로 바뀌게 변경하였습니다.
  - 사유: 로그인 직후 토큰값을 설정하고 다시 refresh 를 수행하는 이슈를 해결합니다.
- setter 와 refreshed 상태 관련하여 테스트 코드를 보완하였습니다.

### `createTokenRefresher` 함수 추가

- JWT 를 통한 refresh 기능을 자동으로 수행하는 헤더 생성자 (headers creator)를 만들 때 쓰입니다.
- 이 곳에 쓰이는 token refresher 함수를 보다 간단하게 만들 수 있습니다.
