### PR TITLE
Hotfix: page size refiner 가 숫자형 외 타입을 의도대로 처리하지 못하는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "typescript based frontend toolkit",
   "repository": {
     "type": "git",

--- a/packages/util/refine.test.ts
+++ b/packages/util/refine.test.ts
@@ -60,6 +60,26 @@ describe('createPageSizeRefiner', () => {
 
     expect(result).toBe(10);
   });
+
+  it('문자열 페이지 값을 주면, 그것을 숫자형으로 자동으로 변환하여 비교한다.', () => {
+    const result = refine('50');
+
+    expect(result).toBe(50);
+  });
+
+  describe('기본 인덱스 설정 예외', () => {
+    it('기본 인덱스 설정이 음수라면 오류를 일으킨다.', () => {
+      expect(() => createPageSizeRefiner(given, -1)).toThrowError(
+        'defaultIndex'
+      );
+    });
+
+    it('페이지 목록의 최대 인덱스를 초과하면 오류를 일으킨다.', () => {
+      expect(() => createPageSizeRefiner(given, 5)).toThrowError(
+        'defaultIndex'
+      );
+    });
+  });
 });
 
 describe('refinePageNumber', () => {

--- a/packages/util/refine.ts
+++ b/packages/util/refine.ts
@@ -83,7 +83,23 @@ export function createEnumRefiner<T>(
  * @returns
  */
 export function createPageSizeRefiner(sizeList: number[], defaultIndex = 0) {
-  return createEnumRefiner(sizeList, sizeList[defaultIndex]);
+  if (defaultIndex < 0 || defaultIndex > sizeList.length - 1) {
+    throw new Error(`invalid defaultIndex: ${defaultIndex}`);
+  }
+
+  return function refineForEnum(target: unknown) {
+    try {
+      const page = Number(target);
+
+      if (sizeList.includes(page)) {
+        return page;
+      }
+    } catch (error) {
+      //
+    }
+
+    return sizeList[defaultIndex];
+  };
 }
 
 /**


### PR DESCRIPTION
## Fixes <!-- 고쳐진 오류들 -->

- createPageSizeRefiner 를 통해 만들어진 정제함수가 number 타입만 제대로 받아들여 수행하는 문제를 해결합니다.
- createPageSizeRefiner 의 두번째 인자 (defaultIndex )의 예외처리를 추가하였습니다.
