### PR TITLE
Feat: useValidate 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "typescript based frontend toolkit",
   "repository": {
     "type": "git",

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -2,13 +2,6 @@ import { DeviceDetectProvider, withAdaptiveRender } from './adaptive-render';
 
 import { cache } from './proxies';
 import { ModuleRouteModel, useRouteSystem } from './route-system';
-import validate, {
-  mergeValidates,
-  ValidateBulkOptionType,
-  ValidateBulkResultModel,
-  ValidateCheckModel,
-  ValidateResultModel,
-} from './validate';
 
 export * from './http-api';
 export * from './hooks';
@@ -17,16 +10,11 @@ export * from './storage';
 export * from './types';
 export * from './util';
 export * from './jwt';
+export * from './validate';
 export {
   ModuleRouteModel,
   DeviceDetectProvider,
   withAdaptiveRender,
   cache,
   useRouteSystem,
-  validate,
-  mergeValidates,
-  ValidateResultModel,
-  ValidateBulkResultModel,
-  ValidateCheckModel,
-  ValidateBulkOptionType,
 };

--- a/packages/validate/index.ts
+++ b/packages/validate/index.ts
@@ -1,7 +1,7 @@
-import { validate } from './validate';
+import { validate as validateOrigin } from './validate';
 import fn from './fn';
 
-type ValidationCheckerType = typeof validate & {
+type ValidationCheckerType = typeof validateOrigin & {
   fn: typeof fn;
 };
 
@@ -19,7 +19,7 @@ type ValidationCheckerType = typeof validate & {
       password: string;
     }
 
-    function execValidation(user: UserModel) {
+    function validateUserModel(user: UserModel) {
       const result = validate(user, {
         // 한가지 검증일 땐 객체로 넘겨준다.
         name: {
@@ -54,11 +54,10 @@ type ValidationCheckerType = typeof validate & {
  * 
  * @see ValidateBulkResultModel
  */
-const validateFn = validate as ValidationCheckerType;
+export const validateFn = validateOrigin as ValidationCheckerType;
 
 validateFn.fn = fn;
 
-export default validateFn;
-
 export * from './mergeValidates';
 export * from './validate.type';
+export * from './useValidate';

--- a/packages/validate/mergeValidates.ts
+++ b/packages/validate/mergeValidates.ts
@@ -17,7 +17,7 @@ import { validateSubUtils } from './validateSubUtils';
  * console.log(result.isValid); // 유효할 경우 true
  * ```
  *
- * @param args 하나로
+ * @param args 하나로 만들 여러 유효성 검증 결과들.
  * @returns {ValidateBulkResultModel}
  */
 export function mergeValidates(

--- a/packages/validate/useValidate.test.tsx
+++ b/packages/validate/useValidate.test.tsx
@@ -1,0 +1,361 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { ChangeEvent } from 'react';
+import { useValidate } from './useValidate';
+import { ValidateBulkResultModel } from './validate.type';
+
+interface TestState {
+  name: string;
+  age: number;
+  hasCookie: boolean;
+}
+
+interface TestProps {
+  validateFn: (data: TestState) => ValidateBulkResultModel;
+}
+
+function getInitState(): TestState {
+  return {
+    name: '죠르디',
+    age: 10,
+    hasCookie: false,
+  };
+}
+
+const SAMPLE_MESSAGE_DIC = {
+  name: '이름은 필수입니다.',
+  age: '나이는 필수입니다!',
+  hasCookie: '쿠키는 가져가셔야 합니다!',
+};
+
+describe('useValidate', () => {
+  function TestComponent({ validateFn }: TestProps) {
+    const fm = useValidate(getInitState, validateFn);
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const { name, value, checked } = event.target;
+
+      if (name === 'name') {
+        fm.setField(name, value);
+      } else if (name === 'age') {
+        fm.setField(name, Number(value));
+      } else if (name === 'hasCookie') {
+        fm.setField(name, checked);
+      }
+    };
+
+    return (
+      <div>
+        <textarea
+          data-testid="antd"
+          defaultValue={JSON.stringify(fm.getAntdStatus('name'))}
+        ></textarea>
+        <textarea
+          data-testid="state"
+          defaultValue={JSON.stringify(fm.state)}
+        ></textarea>
+        <textarea
+          data-testid="message"
+          defaultValue={JSON.stringify(fm.message)}
+        ></textarea>
+        <input
+          data-testid="input.name"
+          type="text"
+          name="name"
+          value={fm.state.name}
+          onChange={handleChange}
+        />
+        <input
+          data-testid="input.age"
+          type="number"
+          name="age"
+          value={fm.state.age}
+          onChange={handleChange}
+        />
+        <input
+          data-testid="input.hasCookie"
+          type="checkbox"
+          name="hasCookie"
+          value="cookie"
+          checked={fm.state.hasCookie}
+          onChange={handleChange}
+        />
+        <button
+          data-testid="btnApplyMessage"
+          onClick={() => fm.setMessage(SAMPLE_MESSAGE_DIC)}
+        >
+          메시지 적용
+        </button>
+        <button data-testid="btnClearMessage" onClick={() => fm.clearMessage()}>
+          메시지 초기화
+        </button>
+        <button data-testid="btnValidate" onClick={() => fm.validate()}>
+          유효성 검증
+        </button>
+        <button data-testid="btnReset" onClick={() => fm.reset()}></button>
+      </div>
+    );
+  }
+
+  function getInputElements() {
+    return {
+      name: screen.getByTestId('input.name'),
+      age: screen.getByTestId('input.age'),
+      hasCookie: screen.getByTestId('input.hasCookie'),
+    };
+  }
+
+  function getButtonElements() {
+    return {
+      applyMessage: screen.getByTestId('btnApplyMessage'),
+      clearMessage: screen.getByTestId('btnClearMessage'),
+      reset: screen.getByTestId('btnReset'),
+      validate: screen.getByTestId('btnValidate'),
+    };
+  }
+
+  function getMessages() {
+    return JSON.parse(screen.getByTestId('message').innerHTML);
+  }
+
+  function doInput(
+    name: keyof ReturnType<typeof getInputElements>,
+    value?: string | boolean
+  ) {
+    if (typeof value === 'string') {
+      fireEvent.input(getInputElements()[name], {
+        target: {
+          value,
+        },
+      });
+
+      return;
+    }
+
+    fireEvent.click(getInputElements()[name]);
+  }
+
+  function doButtonAction(name: keyof ReturnType<typeof getButtonElements>) {
+    fireEvent.click(getButtonElements()[name]);
+  }
+
+  function getState() {
+    return JSON.parse(screen.getByTestId('state').innerHTML);
+  }
+
+  const validateFnMock = vi.fn((_: TestState) => {
+    const result: ValidateBulkResultModel = {
+      isValid: true,
+      results: {},
+      validKeys: [],
+      invalidKeys: [],
+      firstMessage: '',
+      errorMessages: {},
+    };
+
+    return result;
+  });
+
+  beforeEach(() => {
+    validateFnMock.mockClear();
+
+    render(<TestComponent validateFn={validateFnMock} />);
+  });
+
+  it('첫 렌더링 시 메시지 내용은 비어있다.', () => {
+    expect(getMessages()).toEqual({});
+  });
+
+  it('각 필드별로 메시지를 적용할 수 있다.', () => {
+    doButtonAction('applyMessage');
+
+    expect(getMessages()).toEqual({
+      name: expect.stringContaining('필수입니다'),
+      age: expect.stringContaining('필수입니다'),
+      hasCookie: expect.stringContaining('쿠키는'),
+    });
+  });
+
+  describe('setField', () => {
+    beforeEach(() => {
+      doInput('name', '');
+      doInput('age', '');
+    });
+
+    it.each([
+      ['문자열', 'name', '', '코디는 룩핀', '코디는 룩핀'],
+      ['숫자형', 'age', 0, '12', 12],
+      ['체크박스', 'hasCookie', false, true, true],
+    ] as const)(
+      '입력값이 바뀌면 state 값도 바뀐다. - %s',
+      (_, name, prevState, inputValue, nextState) => {
+        expect(getState()[name]).toBe(prevState);
+
+        doInput(name, inputValue);
+
+        expect(getState()[name]).toBe(nextState);
+      }
+    );
+  });
+
+  describe('적용된 메시지는 각 필드에 값이 설정되면 빈 값으로 바뀐다.', () => {
+    beforeEach(() => {
+      doButtonAction('applyMessage');
+    });
+
+    it.each([
+      ['문자열', 'name', '룩핀'],
+      ['숫자형', 'age', '100'],
+      ['체크박스', 'hasCookie', true],
+    ] as const)('%s 입력 - %s 항목만 초기화된다.', (_, name, value) => {
+      doInput(name, value);
+
+      const message = getMessages();
+
+      (['name', 'age', 'hasCookie'] as const).forEach((key) => {
+        if (name === key) {
+          expect(message[key]).toBe('');
+        } else {
+          expect(message[key]).not.toBe('');
+        }
+      });
+    });
+  });
+
+  it('clearMessage 수행 시 적용된 메시지를 모두 제거한다.', () => {
+    doButtonAction('applyMessage');
+
+    expect(getMessages()).not.toEqual({});
+
+    doButtonAction('clearMessage');
+
+    expect(getMessages()).toEqual({});
+  });
+
+  it('reset 수행 시 적용된 메시지와 상태값을 모두 초기화 한다.', () => {
+    doInput('name', '룩핀');
+    doInput('age', '4455');
+    doInput('hasCookie', true);
+    doButtonAction('applyMessage');
+
+    expect(getMessages()).not.toEqual({});
+
+    expect(getState()).toEqual({
+      name: '룩핀',
+      age: 4455,
+      hasCookie: true,
+    });
+
+    doButtonAction('reset');
+
+    expect(getMessages()).toEqual({});
+    expect(getState()).toEqual(getInitState());
+  });
+
+  describe('validate - 유효성 검증 수행', () => {
+    it('유효성 검증 시 적용된 검증 함수를 수행한다.', () => {
+      expect(validateFnMock).not.toBeCalled();
+
+      doButtonAction('validate');
+
+      expect(validateFnMock).toBeCalled();
+    });
+
+    it('유효성 검증 성공 시 기존 메시지는 초기화된다.', () => {
+      expect(getMessages()).toEqual({});
+
+      doButtonAction('applyMessage');
+
+      expect(getMessages()).toEqual(SAMPLE_MESSAGE_DIC);
+
+      doButtonAction('validate');
+
+      expect(getMessages()).toEqual({});
+    });
+
+    it('유효성 검증 실패 후 발생된 메시지를 반영시킨다.', () => {
+      const messageDic = {
+        name: '하나면 하나지 둘이겠느냐',
+        age: '둘이면 둘이지',
+        hasCookie: '셋이겠느냐',
+      };
+
+      validateFnMock.mockImplementationOnce(() => {
+        const result: ValidateBulkResultModel = {
+          isValid: false,
+          results: {},
+          validKeys: [],
+          invalidKeys: [],
+          firstMessage: messageDic.name,
+          errorMessages: messageDic,
+        };
+        return result;
+      });
+
+      expect(getMessages()).toEqual({});
+
+      doButtonAction('applyMessage');
+
+      expect(getMessages()).toEqual(SAMPLE_MESSAGE_DIC);
+
+      doButtonAction('validate');
+
+      expect(getMessages()).toEqual(messageDic);
+    });
+
+    it('유효성 검증에 일부만 실패 시, 실패한 필드 메시지만 반영된다.', () => {
+      const errorMessage = '포메는 사랑입니다 ^^';
+
+      validateFnMock.mockImplementationOnce(() => {
+        const result: ValidateBulkResultModel = {
+          isValid: false,
+          results: {},
+          validKeys: ['age', 'hasCookie'],
+          invalidKeys: ['name'],
+          firstMessage: errorMessage,
+          errorMessages: {
+            name: errorMessage,
+          },
+        };
+        return result;
+      });
+
+      expect(getMessages()).toEqual({});
+
+      doButtonAction('validate');
+
+      expect(getMessages()).toEqual({
+        name: errorMessage,
+      });
+    });
+  });
+
+  describe('getAntdStatus - antd Form.Item 호환 상태값', () => {
+    function getAntdStatus() {
+      return JSON.parse(screen.getByTestId('antd').innerHTML);
+    }
+
+    it('필드 메시지가 없다면 빈 객체를 반환한다.', () => {
+      expect(getAntdStatus()).toEqual({});
+    });
+
+    it('필드 메시지가 있다면, 메시지와 error 가 포함된 객체를 반환한다.', () => {
+      doButtonAction('applyMessage');
+
+      expect(getAntdStatus()).toEqual({
+        help: expect.stringContaining('필수'),
+        validateStatus: 'error',
+      });
+    });
+
+    it('필드에 메시지가 있다가 없어지면 다시 빈 객체를 반환한다.', () => {
+      doButtonAction('applyMessage');
+
+      expect(getAntdStatus()).not.toEqual({});
+
+      doButtonAction('clearMessage');
+
+      expect(getAntdStatus()).toEqual({});
+    });
+  });
+});

--- a/packages/validate/useValidate.ts
+++ b/packages/validate/useValidate.ts
@@ -1,0 +1,286 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  AntdFormItemValidationMessageDto,
+  ValidateBulkResultModel,
+} from './validate.type';
+import { validateSubUtils } from './validateSubUtils';
+
+interface FieldDispatch<T> {
+  (name: keyof T, value: any): void;
+  (name: string, value: any): void;
+  (next: Partial<T>): void;
+  (setter: (prev: T) => Partial<T>): void;
+}
+
+interface MessageDispatch<T> {
+  (name: keyof T, message: string): void;
+  (messageDic: Partial<{ [key in keyof T]: string }>): void;
+}
+
+interface ValidateHookResult<T> {
+  /**
+   * 사용될 상태값.
+   */
+  state: T;
+  /**
+   * 각 상태 항목별 오류 메시지가 담긴 객체.
+   */
+  message: Partial<Record<keyof T, string>>;
+  /**
+   * 특정 필드의 상태값을 바꾼다.
+   *
+   * 변경된 필드명에 대응되는 오류 메시지는 자동으로 빈값으로 초기화된다.
+   */
+  setField: FieldDispatch<T>;
+  /**
+   * 특정 필드의 메시지값을 바꾼다.
+   */
+  setMessage: MessageDispatch<T>;
+  /**
+   * 현재 지정된 오류 메시지를 모두 빈값으로 초기화한다.
+   */
+  clearMessage(): void;
+  /**
+   * 메시지와 상태값을 모두 초기 상태로 되돌린다.
+   */
+  reset(): void;
+  /**
+   * 설정된 내부 상태값을 기반으로 유효성 검증을 수행한다.
+   *
+   * 검증에 실패했을 경우, 발생된 에러 메시지를 모두 `message` 필드에 자동으로 반영한다.
+   */
+  validate(): ValidateBulkResultModel;
+  /**
+   * antd 에서 Form.Item 과 응용할 때 쓰인다.
+   * @example
+   * ```tsx
+   * const { state, setField, getAntdStatus } = useValidate({ name: '' });
+   *
+   * <Form.Item {...getAntdStatus('name')}>
+   *   <Input
+   *     value={status.name}
+   *     onChange={(e) => setField('name', e.target.value)}
+   *   />
+   * </Form.Item>
+   * ```
+   * @param name 메시지와 상태를 가져올 필드명.
+   */
+  getAntdStatus(name: keyof T): AntdFormItemValidationMessageDto;
+}
+
+function getValidStatus(msg?: string): AntdFormItemValidationMessageDto {
+  if (!msg) {
+    return {};
+  }
+  return {
+    validateStatus: 'error',
+    help: msg,
+  };
+}
+
+function dispatchField<T>(
+  setState: Dispatch<SetStateAction<T>>,
+  setMessage: Dispatch<SetStateAction<Partial<Record<keyof T, string>>>>,
+  prevValue: T,
+  arg0: keyof T | Partial<T> | ((prev: T) => Partial<T>),
+  arg1: T[keyof T]
+) {
+  if (typeof arg0 === 'string') {
+    const name = arg0;
+    const value = arg1;
+
+    setState((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    setMessage((prev) => ({
+      ...prev,
+      [name]: '',
+    }));
+
+    return;
+  }
+
+  let nextValue: Partial<T>;
+
+  if (typeof arg0 === 'function') {
+    nextValue = arg0({ ...prevValue });
+  } else if (typeof arg0 === 'object') {
+    nextValue = arg0;
+  } else {
+    return;
+  }
+
+  setState({
+    ...prevValue,
+    ...nextValue,
+  });
+  setMessage((prev) => {
+    return Object.keys(nextValue).reduce(
+      (acc, key) => {
+        acc[key as keyof T] = '';
+
+        return acc;
+      },
+      { ...prev }
+    );
+  });
+}
+
+/**
+ * 유효성 검증과 상태 제어 기능을 제공하는 훅스.
+ * @param initData 설정할 초기 데이터
+ * @param validateFn 유효성 검증에 필요한 함수. 설정하지 않으면 유효성 검증을 무시한다.
+ * @returns
+ *
+ * @example
+ * ```tsx
+ * import { validate, useValidate } from 'jordy';
+ *
+ * function validateData(data: MyModel) {
+ *   return validate(data, {
+ *     // 유효성 검증 코드
+ *   });
+ * }
+ *
+ * function ViewComponent() {
+ *   const {
+ *     state,
+ *     setField,
+ *     message,
+ *     validate,
+ *     getAntdStatus
+ *   } = useValidate(
+ *     createMyModel,
+ *     validateData,
+ *   );
+ *
+ *   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+ *     e.preventDefault();
+ *
+ *     const result = validate();
+ *
+ *     if (result.isValid) {
+ *       alert('작성 완료!');
+ *     } else {
+ *       alert(result.firstMessage);
+ *     }
+ *   };
+ *
+ *   return (
+ *     <form onSubmit={handleSubmit}>
+ *       <input
+ *         value={state.textInput}
+ *         onChange={({ target }) => setField('textInput', target.value)}
+ *       />
+ *       <p>{message.textInput}</p>
+ *
+ *       -- antd 활용 --
+ *       <Form.Item {...getAntdStatus('textInput')}>
+ *         <Input
+ *           value={state.textInput}
+ *           onChange={({ target }) => setField('textInput', target.value)}
+ *         />
+ *       </Form.Item>
+ *
+ *       <button>보내기</button>
+ *     </form>
+ *   );
+ * }
+ * ```
+ */
+export function useValidate<T extends Record<string, any>>(
+  initData: T | (() => T),
+  validateFn?: (data: T) => ValidateBulkResultModel
+): ValidateHookResult<T> {
+  const [state, setState] = useState(initData);
+  const refInitState = useRef(state);
+  const refState = useRef(state);
+  const [message, setMessage] = useState<Partial<Record<keyof T, string>>>({});
+
+  useLayoutEffect(() => {
+    refState.current = state;
+  }, [state]);
+
+  const setField = useCallback(
+    ((
+      arg0: keyof T | Partial<T> | ((prev: T) => Partial<T>),
+      arg1: T[keyof T]
+    ) => {
+      dispatchField(setState, setMessage, refState.current, arg0, arg1);
+    }) as FieldDispatch<T>,
+    []
+  );
+
+  const setFieldMessage = useCallback(
+    ((arg0: keyof T | Partial<{ [key in keyof T]: string }>, arg1: string) => {
+      if (typeof arg0 === 'object') {
+        setMessage((prev) => ({
+          ...prev,
+          ...arg0,
+        }));
+
+        return;
+      }
+
+      setMessage((prev) => ({
+        ...prev,
+        [arg0]: arg1,
+      }));
+    }) as MessageDispatch<T>,
+    []
+  );
+
+  const clearMessage = useCallback(() => {
+    setMessage({});
+  }, []);
+
+  const reset = useCallback(() => {
+    setMessage({});
+    setState(refInitState.current);
+  }, []);
+
+  const getAntdStatus = useCallback(
+    (name: keyof T) => {
+      return getValidStatus(message[name]);
+    },
+    [message]
+  );
+
+  const doValidate = useCallback(() => {
+    if (!validateFn) {
+      return validateSubUtils.createValidateBulkResultModel();
+    }
+
+    const result = validateFn(refState.current);
+
+    if (result.isValid === false) {
+      setMessage(result.errorMessages as Partial<Record<keyof T, string>>);
+
+      return result;
+    }
+
+    setMessage({});
+
+    return result;
+  }, [validateFn]);
+
+  return {
+    state,
+    message,
+    setField,
+    setMessage: setFieldMessage,
+    clearMessage,
+    reset,
+    validate: doValidate,
+    getAntdStatus,
+  };
+}

--- a/packages/validate/validate.ts
+++ b/packages/validate/validate.ts
@@ -14,7 +14,7 @@ export function validate<T>(
   return Object.keys(opt).reduce((acc, key) => {
     const val = (state as any)[key];
     const items = (opt as any)[key];
-    const _mRet = validateBulk(val, items);
+    const _mRet = validateBulk(val, state, items);
 
     acc.results[key] = _mRet;
     acc.isValid = acc.isValid && _mRet.result;

--- a/packages/validate/validate.type.ts
+++ b/packages/validate/validate.type.ts
@@ -59,15 +59,15 @@ export interface ValidateBulkResultModel extends ErrorMessagesModel {
 /**
  * 유효성 체크 요청에 쓰이는 모델.
  */
-export interface ValidateCheckModel<T> {
+export interface ValidateCheckModel<T, S> {
   /**
    * 해당 유효성 체크를 무시하는 조건.
    *
    * 설정하여 그 결과값이 true 라면 해당 필드의 모든 유효성 체크를 무시한다.
    *
-   * 설정 시 가장 첫번째 유효성 체크 설정에만 유효하다.
+   * 가장 첫번째 유효성 체크 설정에만 유효하다.
    */
-  ignore?: ((val: T) => boolean) | boolean;
+  ignore?: ((val: T, state: S) => boolean) | boolean;
   /**
    * 유효성 체크에 실패 했을 때 출력될 메시지
    */
@@ -77,7 +77,7 @@ export interface ValidateCheckModel<T> {
    *
    * 결과가 false 면 유효성 체크에 실패 한 것으로 간주한다.
    */
-  check: (val: T) => boolean;
+  check: (val: T, state: S) => boolean;
 }
 
 /**
@@ -95,7 +95,21 @@ export type ValidateBulkOptionType<T extends Record<string, any>> = {
    * 또 한 각 필드의 ignore 가 true 일 경우 그 필드 내 다음 조건은 무시하고 통과 된 것으로 간주한다.
    */
   [key in keyof T]?:
-    | ValidateCheckModel<T[key]>
-    | ValidateCheckModel<T[key]>[]
-    | ((value: T[key]) => ValidateBulkResultModel);
+    | ValidateCheckModel<T[key], T>
+    | ValidateCheckModel<T[key], T>[]
+    | ((value: T[key], state: T) => ValidateBulkResultModel);
 };
+
+/**
+ * antd 의 Form.Item 컴포넌트에 응용되는 유효성 체크 자료.
+ */
+export interface AntdFormItemValidationMessageDto {
+  /**
+   * 오류여부
+   */
+  validateStatus?: 'error';
+  /**
+   * 알려줄 유효성 메시지
+   */
+  help?: string;
+}

--- a/packages/validate/validateSubUtils.ts
+++ b/packages/validate/validateSubUtils.ts
@@ -16,11 +16,12 @@ function createValidateBulkResultModel() {
   return result;
 }
 
-function validateSingle<T>(
+function validateSingle<T, S>(
   val: T,
-  { check, message }: ValidateCheckModel<T>
+  state: S,
+  { check, message }: ValidateCheckModel<T, S>
 ): ValidateResultModel {
-  const result = check(val);
+  const result = check(val, state);
   const msg = !result ? message : '';
 
   return {
@@ -29,14 +30,15 @@ function validateSingle<T>(
   };
 }
 
-function checkIgnore<T>(
-  ignore: undefined | boolean | ((val: T) => boolean),
-  val: T
+function checkIgnore<T, S>(
+  ignore: undefined | boolean | ((val: T, state: S) => boolean),
+  val: T,
+  state: S
 ) {
   if (!ignore) {
     return false;
   }
-  return ignore === true || ignore(val);
+  return ignore === true || ignore(val, state);
 }
 
 function createValidateResultModel(): ValidateResultModel {
@@ -46,22 +48,23 @@ function createValidateResultModel(): ValidateResultModel {
   };
 }
 
-function validateBulk<T>(
+function validateBulk<T, S>(
   val: T,
+  state: S,
   opt:
-    | ValidateCheckModel<T>
-    | ValidateCheckModel<T>[]
+    | ValidateCheckModel<T, S>
+    | ValidateCheckModel<T, S>[]
     | ((value: T) => ValidateBulkResultModel)
 ): ValidateResultModel {
   let mRes: ValidateResultModel | undefined;
 
   if (Array.isArray(opt)) {
-    if (opt.length > 0 && checkIgnore(opt[0].ignore, val)) {
+    if (opt.length > 0 && checkIgnore(opt[0].ignore, val, state)) {
       return createValidateResultModel();
     }
 
     opt.every((_opt) => {
-      const _mRes = validateSingle(val, _opt);
+      const _mRes = validateSingle(val, state, _opt);
 
       if (!_mRes.result) {
         mRes = _mRes;
@@ -76,11 +79,11 @@ function validateBulk<T>(
       message: tmpRes.firstMessage,
     };
   } else {
-    if (checkIgnore(opt.ignore, val)) {
+    if (checkIgnore(opt.ignore, val, state)) {
       return createValidateResultModel();
     }
 
-    mRes = validateSingle(val, opt);
+    mRes = validateSingle(val, state, opt);
   }
 
   return mRes || createValidateResultModel();


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

- 유효성 검증 기능과 컴포넌트 상태, 그리고 에러 메시지를 함께 편리하게 사용 할 수 있는 `useValidate` 훅스를 추가합니다.
- validate 사용 시 처음 넘겨준 데이터 객체를 각 필드 검증마다 두번째 인자로 받아와서 확인 할 수 있도록 사용성을 개선하였습니다.

## Notes <!-- 리뷰어에게 알려줄 내용이나 PR에 히스토리로 남기고 싶은 내용들 -->

- PR을 쪼갤까 하다가, 아무래도 useValidate 본 기능과 테스트 코드를 함께 보는게 나을 것 같아서 한번에 올립니다~
- 그래서 변경 내용이 500 라인 넘은 점, 양해바랍니다~ 🙏 
