### PR TITLE
Feat: queryString 의 serialize 수행 기능 보완 외

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "description": "typescript based frontend toolkit",
   "repository": {
     "type": "git",

--- a/packages/util/typeCheck.ts
+++ b/packages/util/typeCheck.ts
@@ -82,7 +82,7 @@ export function isFunction(val: unknown): val is CallableFunction {
  * @param val
  * @returns
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export function isObject(val: unknown): val is Object {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isObject(val: unknown): val is Record<string, any> {
   return Object.prototype.toString.call(val) === '[object Object]';
 }


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

- `queryString.serialize` 수행 시 문자열, 숫자 혹은 객체형 배열에 대한 예외 처리를 추가합니다.
  - 관련하여 테스트 코드를 추가하였고 기존 코드를 일부 개선하였습니다.
- `isObject` 를 통한 type guard 결과를 `Record<string, any>` 로 변경합니다.
  - 사유: 원래 취지는 plain object 감별이었는데, 생각보다 잡다한 타입들이 다 통과되어서 변경합니다.

## Notes <!-- 리뷰어에게 알려줄 내용이나 PR에 히스토리로 남기고 싶은 내용들 -->

- 개발 업무 진행중이라 먼저 master 에 반영 하겠습니다! 🙇‍♂️ 
