### PR TITLE
Hotfix: ErrorParser 기능 보완

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "typescript based frontend toolkit",
   "repository": {
     "type": "git",

--- a/packages/http-api/ErrorParser.decorator.ts
+++ b/packages/http-api/ErrorParser.decorator.ts
@@ -2,6 +2,7 @@
 import {
   AsyncHttpNetworkProvider,
   AsyncHttpUploadProvider,
+  RestHttpMethodType,
 } from './network.type';
 import { throwHttpRestError } from './network.util';
 
@@ -30,7 +31,9 @@ function isConstructor(val: unknown): val is ConstructorType {
  * @see AsyncHttpNetworkProvider
  * @see AsyncHttpUploadProvider
  */
-export function ErrorParser<E = any>(throwableParser: (error: E) => any) {
+export function ErrorParser<E = any>(
+  throwableParser: (error: E, method: RestHttpMethodType, url: string) => any
+) {
   return function <C extends ConstructorType>(ClassConstructor: C): C {
     if (isConstructor(ClassConstructor) === false) {
       throw new Error('ErrorParser: argument is not function.');
@@ -45,8 +48,8 @@ export function ErrorParser<E = any>(throwableParser: (error: E) => any) {
         this.network = new ClassConstructor(args[0], args[1], args[2]);
       }
 
-      parse = async (error: any) => {
-        const nextError = throwableParser(error);
+      parse = async (error: any, method: RestHttpMethodType, url: string) => {
+        const nextError = throwableParser(error, method, url);
 
         if (nextError) {
           throw nextError;
@@ -58,32 +61,32 @@ export function ErrorParser<E = any>(throwableParser: (error: E) => any) {
       get(...args: any[]) {
         return this.network.get
           .apply(this.network, [...args])
-          .catch(this.parse);
+          .catch((err: any) => this.parse(err, 'get', args[0]));
       }
       post(...args: any[]) {
         return this.network.post
           .apply(this.network, [...args])
-          .catch(this.parse);
+          .catch((err: any) => this.parse(err, 'post', args[0]));
       }
       put(...args: any[]) {
         return this.network.put
           .apply(this.network, [...args])
-          .catch(this.parse);
+          .catch((err: any) => this.parse(err, 'put', args[0]));
       }
       patch(...args: any[]) {
         return this.network.patch
           .apply(this.network, [...args])
-          .catch(this.parse);
+          .catch((err: any) => this.parse(err, 'patch', args[0]));
       }
       delete(...args: any[]) {
         return this.network.delete
           .apply(this.network, [...args])
-          .catch(this.parse);
+          .catch((err: any) => this.parse(err, 'delete', args[0]));
       }
       getBlob(...args: any[]) {
         return this.network.getBlob
           .apply(this.network, [...args])
-          .catch(this.parse);
+          .catch((err: any) => this.parse(err, 'get', args[0]));
       }
     } as C;
   };

--- a/packages/http-api/HttpRestError.ts
+++ b/packages/http-api/HttpRestError.ts
@@ -1,6 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { RestHttpMethodType } from './network.type';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export type HttpRestErrorType =
   | 'unknown'
   | 'auth'
@@ -24,7 +24,8 @@ export interface HttpRestErrorMetaArgs {
   url: string;
   method?: RestHttpMethodType;
   rawData: any;
-  status: number;
+  status?: number;
+  errorType?: HttpRestErrorType;
 }
 
 export interface HttpRestErrorLike extends ErrorLike, HttpRestErrorMeta {}
@@ -83,7 +84,9 @@ export class HttpRestError implements Error, HttpRestErrorLike {
     if (typeof arg !== 'string' && arg) {
       this.url = arg.url || '';
       this.method = arg.method;
-      this.errorType = this.toErrorType(Number(arg.status));
+      this.errorType = arg.errorType
+        ? arg.errorType
+        : this.toErrorType(Number(arg.status));
       this.rawData = arg.rawData;
     }
   }
@@ -119,6 +122,19 @@ export class HttpRestError implements Error, HttpRestErrorLike {
       return 'badRequest';
     }
     return 'unknown';
+  }
+
+  static toStatusCodeFrom(type: HttpRestErrorType) {
+    const dic: Record<HttpRestErrorType, number> = {
+      auth: 401,
+      forbidden: 403,
+      notFound: 404,
+      server: 500,
+      badRequest: 400,
+      unknown: 0,
+    };
+
+    return dic[type];
   }
 
   static isHttpRestErrorType(value: unknown): value is HttpRestErrorType {

--- a/packages/http-api/axios/throwableAxiosErrorParser.test.ts
+++ b/packages/http-api/axios/throwableAxiosErrorParser.test.ts
@@ -1,4 +1,4 @@
-import { HttpRestError } from '../HttpRestError';
+import { ErrorLike, HttpRestError, HttpRestErrorLike } from '../HttpRestError';
 import { throwableAxiosErrorParser } from './throwableAxiosErrorParser';
 
 vi.mock('./axios.util', () => {
@@ -9,6 +9,7 @@ vi.mock('./axios.util', () => {
 
 describe('throwableAxiosErrorParser', async () => {
   const { isAxiosError } = await import('./axios.util');
+  const GIVEN_URL = 'https://api.blah.com/list';
 
   beforeEach(() => {
     vi.mocked(isAxiosError).mockClear();
@@ -19,143 +20,233 @@ describe('throwableAxiosErrorParser', async () => {
 
   it('수행 시 에러 형태가 AxiosError 내용과 흡사한지 확인한다.', () => {
     vi.mocked(isAxiosError).mockImplementationOnce(() => false);
-    throwableAxiosErrorParser(null);
+    expect(() => throwableAxiosErrorParser(null, 'get', GIVEN_URL)).toThrow();
 
     expect(isAxiosError).toHaveLastReturnedWith(false);
   });
 
-  it('에러 형태가 AxiosError 가 아닐 경우 아무것도 하지 않는다.', () => {
-    vi.mocked(isAxiosError).mockImplementationOnce(() => false);
-    expect(() =>
-      throwableAxiosErrorParser({ message: 'blah' })
-    ).not.toThrowError();
-  });
-
   describe('AxiosError 내용일 때', () => {
-    it('메타 데이터와 오류 데이터가 포함된다.', () => {
-      expect.assertions(2);
+    const AXIOS_ERROR_MOCK = {
+      response: {
+        data: {
+          message: 'lookpin',
+        },
+        status: 404,
+      },
+      config: {
+        url: '/some/path/10',
+        method: 'delete',
+      },
+    };
 
-      try {
-        throwableAxiosErrorParser({
-          response: {
-            data: {
-              message: 'lookpin',
-            },
-            status: 404,
-          },
-          config: {
-            url: '/some/path/10',
-            method: 'delete',
-          },
-        });
-      } catch (error) {
-        expect(error).toBeInstanceOf(HttpRestError);
-        expect((error as HttpRestError).toPlainObject()).toEqual({
+    it('만들어진 오류 객체는 HttpRestError 타입의 인스턴스이다.', () => {
+      expect(() =>
+        throwableAxiosErrorParser(AXIOS_ERROR_MOCK, 'get', GIVEN_URL)
+      ).toThrow(HttpRestError);
+    });
+    it('메타 데이터와 오류 데이터가 포함된다.', () => {
+      expect(() =>
+        throwableAxiosErrorParser(AXIOS_ERROR_MOCK, 'get', GIVEN_URL)
+      ).toThrow(
+        expect.objectContaining({
           message: 'lookpin',
           errorType: 'notFound',
           url: '/some/path/10',
           method: 'delete',
-          rawData: expect.objectContaining({
-            message: 'lookpin',
-          }),
-        });
-      }
+          rawData: AXIOS_ERROR_MOCK.response.data,
+        })
+      );
     });
 
     it('응답 데이터가 html 문서라면 기본 메시지가 적용된다.', () => {
-      expect.assertions(2);
+      const given = {
+        response: {
+          data: `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en">
+<head>
+  <title>lookpin - korean best shopping platform</title>
+</head>
+<body style="background: gray">
+  <p>
+  lorem ipsum blah blah..
+  </p>
+</body>
+</html>`,
+          status: 500,
+        },
+        config: {
+          url: '/some/path',
+          method: 'PUT',
+        },
+      };
 
-      try {
-        throwableAxiosErrorParser({
-          response: {
-            data: `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-  <html lang="en">
-    <head>
-      <title>lookpin - korean best shopping platform</title>
-    </head>
-    <body style="background: gray">
-      <p>
-      lorem ipsum blah blah..
-      </p>
-    </body>
-  </html>`,
-            status: 500,
-          },
-          config: {
-            url: '/some/path',
-            method: 'PUT',
-          },
-        });
-      } catch (error) {
-        expect(error).toBeInstanceOf(HttpRestError);
-        expect((error as HttpRestError).toPlainObject()).toEqual({
+      expect(() => throwableAxiosErrorParser(given, 'get', GIVEN_URL)).toThrow(
+        expect.objectContaining({
           message: HttpRestError.DEFAULT_MESSAGE,
           errorType: 'server',
           url: '/some/path',
           method: 'put',
           rawData: expect.stringContaining('lorem'),
-        });
-      }
+        })
+      );
     });
 
     it('응답 데이터가 일반 문자열이면 그 내용이 메시지에 포함된다.', () => {
-      expect.assertions(2);
+      const given = {
+        response: {
+          data: 'lookpin lover',
+          status: 401,
+        },
+        config: {
+          method: 'POST',
+          url: '/some/path',
+        },
+      };
 
-      try {
-        throwableAxiosErrorParser({
-          response: {
-            data: 'lookpin lover',
-            status: 401,
-          },
-          config: {
-            method: 'POST',
-            url: '/some/path',
-          },
-        });
-      } catch (error) {
-        expect(error).toBeInstanceOf(HttpRestError);
-        expect((error as HttpRestError).toPlainObject()).toEqual({
+      expect(() => throwableAxiosErrorParser(given, 'get', GIVEN_URL)).toThrow(
+        expect.objectContaining({
           message: 'lookpin lover',
           errorType: 'auth',
           url: '/some/path',
           method: 'post',
           rawData: expect.stringContaining('lover'),
-        });
-      }
+        })
+      );
     });
 
     it('응답 데이터가 해석될 수 없다면 응답된 데이터는 rawData 에서 확인 가능하며, 기본 메시지가 적용된다.', () => {
-      expect.assertions(2);
-
-      try {
-        throwableAxiosErrorParser({
-          response: {
-            data: {
-              meta: {
-                items: [1, 2, 3, 4, 5],
-              },
-            },
-            status: '404',
-          },
-          config: {
-            url: '/some/path',
-          },
-        });
-      } catch (error) {
-        expect(error).toBeInstanceOf(HttpRestError);
-        expect((error as HttpRestError).toPlainObject()).toEqual({
-          message: HttpRestError.DEFAULT_MESSAGE,
-          errorType: 'notFound',
-          url: '/some/path',
-          method: undefined,
-          rawData: {
+      const given = {
+        response: {
+          data: {
             meta: {
               items: [1, 2, 3, 4, 5],
             },
           },
-        });
-      }
+          status: '404',
+        },
+        config: {
+          url: '/some/path',
+        },
+      };
+
+      expect(() => throwableAxiosErrorParser(given, 'get', GIVEN_URL)).toThrow(
+        expect.objectContaining({
+          message: HttpRestError.DEFAULT_MESSAGE,
+          errorType: 'notFound',
+          url: '/some/path',
+          method: 'get',
+          rawData: given.response.data,
+        })
+      );
     });
-    // AxiosError 내용일 때 - [end]
-  });
+  }); // AxiosError 내용일 때 - [end]
+
+  describe('AxiosError 가 아닐 때', () => {
+    beforeEach(() => {
+      vi.mocked(isAxiosError).mockImplementationOnce(() => false);
+    });
+
+    it('method 와 url 정보로 오류내용을 만든다.', () => {
+      const given = { message: 'blah' };
+
+      expect(() => throwableAxiosErrorParser(given, 'get', GIVEN_URL)).toThrow(
+        expect.objectContaining({
+          message: 'blah',
+          method: 'get',
+          url: GIVEN_URL,
+          rawData: given,
+        })
+      );
+    });
+
+    it('method 혹은 url 정보가 없다면 아무것도 하지 않는다.', () => {
+      const given = { message: 'blah' };
+
+      expect(() => throwableAxiosErrorParser(given, 'get', '')).not.toThrow();
+    });
+
+    describe('error 가 HttpRestError 타입일 경우', () => {
+      it('에러 객체의 속성을 그대로 따른다.', () => {
+        const given: HttpRestErrorLike = {
+          message: 'lookpin',
+          method: 'put',
+          url: GIVEN_URL,
+          errorType: 'auth',
+          rawData: {
+            fake: true,
+            jordy: true,
+            happyPoint: 100,
+          },
+        };
+
+        expect(() =>
+          throwableAxiosErrorParser(given, 'get', GIVEN_URL)
+        ).toThrow(expect.objectContaining(given));
+      });
+
+      it('에러 객체의 errorType 이 unknown 일 경우 새로 만들어진 오류의 errorType 도 unknown 이다.', () => {
+        const given: HttpRestErrorLike = {
+          message: 'lookpin',
+          method: 'put',
+          url: GIVEN_URL,
+          errorType: 'unknown',
+          rawData: {
+            fake: true,
+            jordy: true,
+            happyPoint: 100,
+          },
+        };
+
+        expect(() =>
+          throwableAxiosErrorParser(given, 'get', GIVEN_URL)
+        ).toThrow(
+          expect.objectContaining({
+            ...given,
+            errorType: 'unknown',
+          })
+        );
+      });
+
+      it('에러 객체 내 method 나 url 이 비었다면 전달된 인자를 이용하여 채운다.', () => {
+        const given: HttpRestErrorLike = {
+          message: 'lookpin?!',
+          url: '',
+          errorType: 'auth',
+          rawData: {
+            fake: true,
+            jordy: true,
+            happyPoint: 100,
+          },
+        };
+        const fakeUrl = 'some/path/haha';
+
+        expect(() => throwableAxiosErrorParser(given, 'get', fakeUrl)).toThrow(
+          expect.objectContaining({
+            message: given.message,
+            method: 'get',
+            url: fakeUrl,
+            errorType: given.errorType,
+            rawData: given.rawData,
+          })
+        );
+      });
+    });
+
+    it('error 가 ErrorLike 타입일 경우 그 메시지를 그대로 이용한다.', () => {
+      const given: ErrorLike = {
+        message: 'lookpin?!',
+      };
+      const fakeUrl = 'some/path/haha';
+
+      expect(() => throwableAxiosErrorParser(given, 'delete', fakeUrl)).toThrow(
+        expect.objectContaining({
+          message: given.message,
+          method: 'delete',
+          url: fakeUrl,
+          errorType: 'unknown',
+          rawData: given,
+        })
+      );
+    });
+  }); // AxiosError 가 아닐 때 - [end]
 });

--- a/packages/http-api/axios/throwableAxiosErrorParser.ts
+++ b/packages/http-api/axios/throwableAxiosErrorParser.ts
@@ -4,21 +4,26 @@ import { RestHttpMethodType } from '../network.type';
 import { isAxiosError } from './axios.util';
 
 function tryGetMethod(
-  method: string | undefined
-): RestHttpMethodType | undefined {
+  method: string | undefined,
+  def: RestHttpMethodType
+): RestHttpMethodType {
   try {
-    return method.toLocaleLowerCase() as RestHttpMethodType;
+    return (method.toLocaleLowerCase() || def) as RestHttpMethodType;
   } catch (error) {
-    return undefined;
+    return def;
   }
 }
 
-export function throwableAxiosErrorParser(error: any) {
+export function throwableAxiosErrorParser(
+  error: any,
+  method: RestHttpMethodType,
+  url: string
+) {
   if (isAxiosError(error)) {
     const errorData = error.response?.data;
     const meta: HttpRestErrorMetaArgs = {
-      url: error.config.url || '',
-      method: tryGetMethod(error.config.method),
+      url: error.config.url || url,
+      method: tryGetMethod(error.config.method, method),
       status: Number(error.response?.status || 0),
       rawData: errorData,
     };
@@ -31,6 +36,31 @@ export function throwableAxiosErrorParser(error: any) {
         throw new HttpRestError(HttpRestError.DEFAULT_MESSAGE, meta);
       }
       throw new HttpRestError(errorData, meta);
+    }
+
+    throw new HttpRestError(HttpRestError.DEFAULT_MESSAGE, meta);
+  }
+
+  if (method && url) {
+    if (HttpRestError.isHttpRestErrorLike(error)) {
+      throw new HttpRestError(error.message, {
+        method: error.method || method,
+        url: error.url || url,
+        status: HttpRestError.toStatusCodeFrom(error.errorType),
+        errorType: error.errorType,
+        rawData: error.rawData,
+      });
+    }
+
+    const meta = {
+      method,
+      url,
+      status: 0,
+      rawData: error,
+    };
+
+    if (HttpRestError.isErrorLike(error)) {
+      throw new HttpRestError(error.message, meta);
     }
 
     throw new HttpRestError(HttpRestError.DEFAULT_MESSAGE, meta);

--- a/packages/jwt/jwt.type.ts
+++ b/packages/jwt/jwt.type.ts
@@ -32,6 +32,8 @@ export interface JWTProvider {
   set(tokenValue: JWTAuthTokenDto): void;
   /**
    * 엑세스 토큰값을 가져온다.
+   * 
+   * @throws 가져오는데 실패 했다면 오류를 일으킨다.
    */
   get(): Promise<string>;
   /**


### PR DESCRIPTION
## Fixes <!-- 고쳐진 오류들 -->

- HttpApi 가 ErrorParser Decorator 를 거쳐서 오류를 일으킬 때 어떠한 요청(method, url)에 따라 발생된 오류인지 정보를 제공하지 않는 문제가 있어 수정합니다.

## Notes

- 기존엔 header 에서 오류가 발생되면 method 와 url 을 담지 않았습니다.
- 이 부분을 ErrorParser 데코레이터에서 받아들이는 하위 error parser 의 수행 시 필요한 인자를 아래와 같이 변경하여 해결하였습니다.
  - as is : 오류 객체 - 1개
  - to be : 오류 객체, 메서드, URL - 3개
- 관련하여 변경된 사항이 많아 이를 체크하기 위해 테스트코드가 일부 변경 되었습니다.
