### PR TITLE
Feat: queue decorator 추가, cache 에 clear 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.20.12",
+  "version": "0.21.0",
   "description": "typescript based frontend toolkit",
   "repository": {
     "type": "git",

--- a/packages/cache/cache.ts
+++ b/packages/cache/cache.ts
@@ -1,5 +1,6 @@
 import { createStorage } from '../storage/createStorage.factory';
-import { CacheConfigDto } from './cache.type';
+import { CacheConfigDto, CachedAsyncFunction } from './cache.type';
+import { clearCacheByKeyword } from './clearCacheByKeyword';
 import { createCacheKey } from './createCacheKey';
 
 /**
@@ -32,7 +33,7 @@ export function cache<R, P = void>({
   type = 'session',
   expired,
   fetcher,
-}: CacheConfigDto<R, P>) {
+}: CacheConfigDto<R, P>): CachedAsyncFunction<R, P> {
   const resultFetcher = async function fetcherProxy(params: P) {
     const sto = createStorage<R>(type, createCacheKey(key, params), expired);
 
@@ -48,6 +49,8 @@ export function cache<R, P = void>({
 
     return newResult;
   };
+
+  resultFetcher.clear = () => clearCacheByKeyword(type, key);
 
   return resultFetcher;
 }

--- a/packages/cache/cache.type.ts
+++ b/packages/cache/cache.type.ts
@@ -26,3 +26,13 @@ export interface CacheConfigDto<R, P> {
    */
   fetcher: (params: P) => Promise<R>;
 }
+
+export interface CachedAsyncFunction<T, P = void> {
+  (params: P): Promise<T>;
+  /**
+   * 현재 저장된 캐시를 제거한다.
+   *
+   * @returns 삭제된 캐시 개수
+   */
+  clear(): number;
+}

--- a/packages/cache/index.ts
+++ b/packages/cache/index.ts
@@ -3,3 +3,4 @@ export * from './cache.type';
 export * from './clearAllCachesExceptBy';
 export * from './clearCacheByKeyword';
 export * from './createCacheKey';
+export * from './queue';

--- a/packages/cache/queue.test.ts
+++ b/packages/cache/queue.test.ts
@@ -1,0 +1,133 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { noop } from '../util/etc';
+import { queue } from './queue';
+import { PromiseResolver } from '../types/etc.type';
+
+function passthrough(middleFn: () => void) {
+  return <T>(value: T): T => {
+    middleFn();
+
+    return value;
+  };
+}
+
+function throwCatch(middleFn: () => void) {
+  return (error: any) => {
+    middleFn();
+
+    return Promise.reject(error);
+  };
+}
+
+describe('queue', () => {
+  const MOCK_DATA = 1234;
+  const resolver: PromiseResolver<never> = {
+    resolve: noop,
+    reject: noop,
+  };
+  const mockFn = vi.fn((..._args: number[]) => {
+    return new Promise((resolve, reject) => {
+      resolver.resolve = resolve;
+      resolver.reject = reject;
+    });
+  });
+
+  beforeEach(() => {
+    mockFn.mockClear();
+  });
+
+  it('비동기 함수를 순간 여럿 수행하면 그 순서대로 응답을 받을 수 있다.', async () => {
+    const queuedFn = queue(mockFn);
+    const seqList: number[] = [];
+
+    const fnList = [
+      queuedFn(1, 2, 3).then(passthrough(() => seqList.push(1))),
+      queuedFn(4, 5, 6).then(passthrough(() => seqList.push(2))),
+      queuedFn(7, 8, 9).then(passthrough(() => seqList.push(3))),
+      queuedFn(10, 11, 12).then(passthrough(() => seqList.push(4))),
+      queuedFn(13, 14, 15).then(passthrough(() => seqList.push(5))),
+    ];
+
+    setTimeout(() => {
+      resolver.resolve(MOCK_DATA as never);
+    }, 5);
+
+    const results = await Promise.all(fnList);
+
+    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toBeCalledWith(1, 2, 3);
+    expect(results).toEqual(seqList.map(() => MOCK_DATA));
+    expect(seqList).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('비동기 함수를 끊어서 여럿 수행하면 그 순서대로 응답을 받을 수 있다.', async () => {
+    const queuedFn = queue(mockFn);
+    const seqList: number[] = [];
+
+    const fnList0 = [
+      queuedFn(4, 5, 6).then(passthrough(() => seqList.push(1))),
+      queuedFn(4, 5, 6).then(passthrough(() => seqList.push(2))),
+      queuedFn(4, 5, 6).then(passthrough(() => seqList.push(3))),
+    ];
+
+    setTimeout(() => {
+      resolver.resolve(MOCK_DATA as never);
+    }, 5);
+
+    const results0 = await Promise.all(fnList0);
+
+    expect(mockFn).toBeCalledWith(4, 5, 6);
+    expect(results0).toEqual(fnList0.map(() => MOCK_DATA));
+
+    const fnList1 = [
+      queuedFn(9, 90, 900).then(passthrough(() => seqList.push(10))),
+      queuedFn(9, 90, 900).then(passthrough(() => seqList.push(11))),
+      queuedFn(9, 90, 900).then(passthrough(() => seqList.push(12))),
+      queuedFn(9, 90, 900).then(passthrough(() => seqList.push(13))),
+    ];
+
+    setTimeout(() => {
+      resolver.resolve(2023 as never);
+    }, 5);
+
+    const results1 = await Promise.all(fnList1);
+
+    expect(mockFn).toBeCalledWith(9, 90, 900);
+    expect(results1).toEqual(fnList1.map(() => 2023));
+
+    expect(mockFn).toBeCalledTimes(2);
+    expect(seqList).toEqual([1, 2, 3, 10, 11, 12, 13]);
+  });
+
+  it('여럿 수행한 결과가 실패면 그 순서대로 사유를 받을 수 있다.', async () => {
+    const error = {
+      name: 'error',
+      message: 'lookpin!',
+    };
+
+    const queuedFn = queue(mockFn);
+    const seqList: number[] = [];
+
+    const fnList = [
+      queuedFn(1, 2, 3).catch(throwCatch(() => seqList.push(1))),
+      queuedFn(1, 2, 3).catch(throwCatch(() => seqList.push(2))),
+      queuedFn(1, 2, 3).catch(throwCatch(() => seqList.push(3))),
+      queuedFn(1, 2, 3).catch(throwCatch(() => seqList.push(4))),
+      queuedFn(1, 2, 3).catch(throwCatch(() => seqList.push(5))),
+    ];
+
+    setTimeout(() => {
+      resolver.reject(error);
+    }, 5);
+
+    const results = await Promise.allSettled(fnList).then((data) =>
+      data.map((datum) => (datum as PromiseRejectedResult).reason)
+    );
+
+    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toBeCalledWith(1, 2, 3);
+
+    expect(results).toEqual(fnList.map(() => error));
+    expect(seqList).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/packages/cache/queue.ts
+++ b/packages/cache/queue.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createAsyncQueue } from '../util/AsyncQueue';
+
+/**
+ * 비동기 함수에 Queue 기능을 추가한다.
+ *
+ * Queue 가 적용되었을 때 해당 함수가 어딘가에서 수행중(pending)일 때 그 외 다른 곳에서 호출하면
+ *
+ * 기다렸다가 첫 호출 응답(성공 or 실패)이 오면, 추가 호출한 순서대로 응답(성공 or 실패)을 연속적으로 내어준다.
+ *
+ * 주의: 매 호출마다 파라미터가 다를 수 있다면 사용에 주의 할 것.
+ *
+ * @example
+ * async function fetcher(name: string, age: number) {
+ *   return timeout(1000, { name, age: age });
+ * }
+ * const queuedFetcher = queue(fetcher);
+ *
+ * const res0 = queuedFetcher('jordy', 10);
+ * const res1 = queuedFetcher('theson', 20);
+ * const res2 = queuedFetcher('lookpin', 30);
+ *
+ * const result = await Promise.all([res0, res1, res2]);
+ *
+ * console.log(result);
+ * // [{ name: 'jordy', age: 10 }, { name: 'jordy', age: 10 }, { name: 'jordy', age: 10 }]
+ *
+ * @param fn Queue 기능을 추가 할 비동기 함수
+ * @returns
+ * @see {AsyncQueue}
+ */
+export function queue<FN extends (...args: any[]) => Promise<any>>(fn: FN): FN {
+  const asyncQueue = createAsyncQueue();
+  let pending = false;
+
+  const resultFetcher = async function (...args: any[]) {
+    if (pending) {
+      return asyncQueue.awaiting();
+    }
+
+    pending = true;
+
+    try {
+      const response = await fn.apply(fn, args);
+
+      if (asyncQueue.has()) {
+        setTimeout(() => {
+          asyncQueue.resolveAll(response);
+        }, 10);
+      }
+
+      pending = false;
+
+      return response;
+    } catch (error) {
+      if (asyncQueue.has()) {
+        setTimeout(() => {
+          asyncQueue.rejectAll(error);
+        }, 10);
+      }
+
+      pending = false;
+
+      throw error;
+    }
+  };
+
+  return resultFetcher as FN;
+}


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

- queue decorator 를 추가합니다.
  - Promise 기반의 비동기 함수를 감싸서 pending 일 경우, 해당 요청들을 queue 로 쌓아놨다가 첫 요청의 응답이 오면 그 순서대로 resolve 혹은 reject 해 주는 유틸리티 입니다.
- cache 에 `clear` 기능을 추가합니다.
  - 캐시된 함수의 캐시를 제거 시, 기존 keyword 기반으로 일일이 삭제 하던 불편함을 줄이기 위해 추가했습니다.
