### PR TITLE
Hotfix: 파라미터가 배열일 때 캐시키 생성이 제대로 안되는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "typescript based frontend toolkit",
   "repository": {
     "type": "git",

--- a/packages/cache/createCacheKey.ts
+++ b/packages/cache/createCacheKey.ts
@@ -15,6 +15,10 @@ export function createCacheKey<P>(
   params?: P,
   subKeys?: Array<keyof P>
 ): string {
+  if (Array.isArray(params)) {
+    return `${key}-${params.join(',')}`;
+  }
+
   if (isObject(params)) {
     let appendedValues: string[];
 
@@ -42,6 +46,7 @@ export function createCacheKey<P>(
 
     return appendedValues.join('-');
   }
+
   if (params && (isString(params) || isNumber(params))) {
     return `${key}-${params}`;
   }


### PR DESCRIPTION
## Fixes <!-- 고쳐진 오류들 -->

cache 나 query hook 기능 이용 시, 전달된 파라미터에 의해 자동으로 만들어지는 캐시키가 순수 배열로만 이뤄졌을 때 제대로 동작이 안되던 부분을 수정합니다.

## Notes <!-- 리뷰어에게 알려줄 내용이나 PR에 히스토리로 남기고 싶은 내용들 -->

- 현재 개발중인 기능에 테스트 해 보기 위해 먼저 배포 한 내용입니다~ 🙌 
- 리뷰가 끝나면 close 예정입니다.