### PR TITLE
Hotfix: isMobile 함수가 아이패드를 모바일로 인지하지 못하는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "description": "typescript based frontend toolkit",
   "repository": {
     "type": "git",

--- a/packages/util/envCheck.ts
+++ b/packages/util/envCheck.ts
@@ -67,7 +67,7 @@ export function isMobile() {
     return false;
   }
 
-  return /iPhone|iPod|Android/.test(ua);
+  return /iPhone|iPad|iPod|Android/.test(ua);
 }
 
 /**


### PR DESCRIPTION
## Fixes <!-- 고쳐진 오류들 -->

- isMobile 유틸 사용 시, 아이패드의 userAgent 를 모바일로 인지하지 못하는 문제가 있어 수정합니다.

## Notes <!-- 리뷰어에게 알려줄 내용이나 PR에 히스토리로 남기고 싶은 내용들 -->

- 미리 배포 된 내용이라 어프롭 뒤 close 예정입니다!
